### PR TITLE
Extract motion event handling into controller

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/MotionEventController.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/MotionEventController.kt
@@ -1,0 +1,71 @@
+package it.palsoftware.pastiera.inputmethod
+
+import android.util.Log
+import android.view.InputDevice
+import android.view.MotionEvent
+import it.palsoftware.pastiera.BuildConfig
+
+class MotionEventController(
+    private val motionEventTracker: MotionEventTracker = MotionEventTracker,
+    private val logTag: String = "MotionEventController",
+    private val debugLogsEnabled: Boolean = BuildConfig.DEBUG
+) {
+
+    fun handle(event: MotionEvent?): Boolean? {
+        if (event == null) {
+            return null
+        }
+
+        val source = event.source
+        val device = event.device
+        val isFromTrackpad = (source and InputDevice.SOURCE_MOUSE) == InputDevice.SOURCE_MOUSE ||
+                (source and InputDevice.SOURCE_TOUCHPAD) == InputDevice.SOURCE_TOUCHPAD
+
+        val isFromKeyboard = device != null &&
+                ((source and InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD ||
+                        device.name?.contains("keyboard", ignoreCase = true) == true ||
+                        device.name?.contains("titan", ignoreCase = true) == true)
+
+        if (isFromTrackpad || isFromKeyboard) {
+            if (debugLogsEnabled) {
+                Log.d(
+                    logTag,
+                    "Motion event intercepted - Action: ${MotionEventTracker.getActionName(event.action)}, " +
+                        "Source: ${MotionEventTracker.getSourceName(source)}, " +
+                        "Device: ${device?.name}, " +
+                        "X: ${event.x}, Y: ${event.y}, " +
+                        "ScrollX: ${event.getAxisValue(MotionEvent.AXIS_HSCROLL)}, " +
+                        "ScrollY: ${event.getAxisValue(MotionEvent.AXIS_VSCROLL)}"
+                )
+            }
+
+            motionEventTracker.notifyMotionEvent(event)
+
+            if (debugLogsEnabled) {
+                when (event.action) {
+                    MotionEvent.ACTION_SCROLL -> {
+                        val scrollX = event.getAxisValue(MotionEvent.AXIS_HSCROLL)
+                        val scrollY = event.getAxisValue(MotionEvent.AXIS_VSCROLL)
+                        Log.d(logTag, "Trackpad scroll detected - X: $scrollX, Y: $scrollY")
+                    }
+
+                    MotionEvent.ACTION_MOVE -> {
+                        Log.d(logTag, "Trackpad move detected - X: ${event.x}, Y: ${event.y}")
+                    }
+
+                    MotionEvent.ACTION_DOWN -> {
+                        Log.d(logTag, "Trackpad touch down detected - X: ${event.x}, Y: ${event.y}")
+                    }
+
+                    MotionEvent.ACTION_UP -> {
+                        Log.d(logTag, "Trackpad touch up detected")
+                    }
+                }
+            }
+
+            return false
+        }
+
+        return null
+    }
+}


### PR DESCRIPTION
## Summary
- add a motion event controller that centralizes trackpad classification, logging, and tracking
- delegate PhysicalKeyboardInputMethodService motion handling to the controller while preserving defaults

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f51db354c832798aa76a6ac68c44b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extracts MotionEvent handling into a reusable controller and delegates `onGenericMotionEvent` from `PhysicalKeyboardInputMethodService` to it, preserving default behavior.
> 
> - **Input handling**:
>   - **New `MotionEventController`**:
>     - Centralizes trackpad/keyboard source detection, debug logging, and `MotionEventTracker` notifications.
>     - Returns `false` for handled motion events, `null` otherwise.
>   - **`PhysicalKeyboardInputMethodService`**:
>     - Instantiates `MotionEventController` and delegates `onGenericMotionEvent(event)` to it.
>     - Falls back to `super.onGenericMotionEvent` when controller returns `null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4326cb435e84e7df6aebc0c50aeeb327ac0a1c49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->