### PR TITLE
Add Russian JCUKEN layout

### DIFF
--- a/app/src/main/assets/common/layouts/russian_jcuken.json
+++ b/app/src/main/assets/common/layouts/russian_jcuken.json
@@ -1,6 +1,6 @@
 {
-  "name": "Russian JCUKEN",
-  "description": "Cyrillic layout for Russian inspired by JCUKEN",
+  "name": "Russian (JCUKEN compact)",
+  "description": "Compact Russian JCUKEN-inspired layout for physical keyboards; optimized for familiarity and reduced travel on constrained key grids.",
   "mappings": {
     "KEYCODE_Q": {
       "lowercase": "й",


### PR DESCRIPTION
[JCUKEN](https://en.wikipedia.org/wiki/JCUKEN) is a popular layout for Russian keyboards. The layout mimics JCUKEN by spreading letters uniformly across the keyboard and placing them roughly at similar physical locations.

The layout favors familiarity to utmost efficiency.

At most 2 taps per letter. Best suited for Unihertz Titan 2.