### PR TITLE
Add option to hide voice input microphone button

### DIFF
--- a/.kotlin/errors/errors-1767554127759.log
+++ b/.kotlin/errors/errors-1767554127759.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/app/build.properties
+++ b/app/build.properties
@@ -1,4 +1,4 @@
 #Build number and date
-#Sat Jan 03 00:42:14 CET 2026
-buildDate=03 gen 2026
-buildNumber=1819
+#Sun Jan 04 20:15:28 CET 2026
+buildDate=04 gen 2026
+buildNumber=1820

--- a/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
@@ -52,6 +52,7 @@ object SettingsManager {
     private const val KEY_CLIPBOARD_RETENTION_TIME = "clipboard_retention_time" // How long to keep clipboard entries (in minutes)
     private const val KEY_TRACKPAD_GESTURES_ENABLED = "trackpad_gestures_enabled" // Whether trackpad gesture suggestions are enabled
     private const val KEY_TRACKPAD_SWIPE_THRESHOLD = "trackpad_swipe_threshold" // Threshold for swipe detection on trackpad
+    private const val KEY_SHOW_VOICE_INPUT_BUTTON = "show_voice_input_button" // Whether to show the voice input microphone button
 
     private const val VARIATIONS_FILE_NAME = "variations.json"
     
@@ -94,6 +95,7 @@ object SettingsManager {
     private const val DEFAULT_TRACKPAD_SWIPE_THRESHOLD = 300f
     private const val MIN_TRACKPAD_SWIPE_THRESHOLD = 120f
     private const val MAX_TRACKPAD_SWIPE_THRESHOLD = 600f
+    private const val DEFAULT_SHOW_VOICE_INPUT_BUTTON = true
 
     /**
      * Returns the SharedPreferences instance for Pastiera.
@@ -1581,6 +1583,26 @@ object SettingsManager {
     fun getMinTrackpadSwipeThreshold(): Float = MIN_TRACKPAD_SWIPE_THRESHOLD
     fun getMaxTrackpadSwipeThreshold(): Float = MAX_TRACKPAD_SWIPE_THRESHOLD
     fun getDefaultTrackpadSwipeThreshold(): Float = DEFAULT_TRACKPAD_SWIPE_THRESHOLD
+
+    /**
+     * Returns whether the voice input microphone button should be shown.
+     * @param context The context
+     * @return Whether the voice input button is enabled
+     */
+    fun getShowVoiceInputButton(context: Context): Boolean {
+        return getPreferences(context).getBoolean(KEY_SHOW_VOICE_INPUT_BUTTON, DEFAULT_SHOW_VOICE_INPUT_BUTTON)
+    }
+
+    /**
+     * Sets whether the voice input microphone button should be shown.
+     * @param context The context
+     * @param enabled Whether to show the voice input button
+     */
+    fun setShowVoiceInputButton(context: Context, enabled: Boolean) {
+        getPreferences(context).edit()
+            .putBoolean(KEY_SHOW_VOICE_INPUT_BUTTON, enabled)
+            .apply()
+    }
 
     /**
      * Returns the File for variations.json in filesDir.

--- a/app/src/main/java/it/palsoftware/pastiera/TextInputSettingsScreen.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/TextInputSettingsScreen.kt
@@ -60,6 +60,10 @@ fun TextInputSettingsScreen(
         mutableStateOf(SettingsManager.getAltCtrlSpeechShortcutEnabled(context))
     }
     
+    var showVoiceInputButton by remember {
+        mutableStateOf(SettingsManager.getShowVoiceInputButton(context))
+    }
+    
     // Handle system back button
     BackHandler { onBack() }
     
@@ -377,6 +381,49 @@ fun TextInputSettingsScreen(
                         onCheckedChange = { enabled ->
                             altCtrlSpeechShortcut = enabled
                             SettingsManager.setAltCtrlSpeechShortcutEnabled(context, enabled)
+                        }
+                    )
+                }
+            }
+
+            // Show Voice Input Button
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.TextFields,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.show_voice_input_button_title),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1
+                        )
+                        Text(
+                            text = stringResource(R.string.show_voice_input_button_description),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1
+                        )
+                    }
+                    Switch(
+                        checked = showVoiceInputButton,
+                        onCheckedChange = { enabled ->
+                            showVoiceInputButton = enabled
+                            SettingsManager.setShowVoiceInputButton(context, enabled)
                         }
                     )
                 }

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/ui/VariationBarView.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/ui/VariationBarView.kt
@@ -592,24 +592,27 @@ class VariationBarView(
         val buttonsContainerView = buttonsContainer ?: return
         buttonsContainerView.removeAllViews()
         
-        val microphoneButton = microphoneButtonView ?: createMicrophoneButton(fixedButtonSize)
-        microphoneButtonView = microphoneButton
-        (microphoneButton.parent as? ViewGroup)?.removeView(microphoneButton)
-        val micParams = LinearLayout.LayoutParams(fixedButtonSize, fixedButtonSize).apply {
-            marginStart = spacingBetweenButtons
-        }
-        buttonsContainerView.addView(microphoneButton, micParams)
-        microphoneButton.setOnClickListener {
-            NotificationHelper.triggerHapticFeedback(context)
-            // Use callback if available (modern SpeechRecognizer approach), otherwise fallback to Activity
-            if (onSpeechRecognitionRequested != null) {
-                onSpeechRecognitionRequested?.invoke()
-            } else {
-                startSpeechRecognition(inputConnection)
+        // Only add microphone button if the setting is enabled
+        if (SettingsManager.getShowVoiceInputButton(context)) {
+            val microphoneButton = microphoneButtonView ?: createMicrophoneButton(fixedButtonSize)
+            microphoneButtonView = microphoneButton
+            (microphoneButton.parent as? ViewGroup)?.removeView(microphoneButton)
+            val micParams = LinearLayout.LayoutParams(fixedButtonSize, fixedButtonSize).apply {
+                marginStart = spacingBetweenButtons
             }
+            buttonsContainerView.addView(microphoneButton, micParams)
+            microphoneButton.setOnClickListener {
+                NotificationHelper.triggerHapticFeedback(context)
+                // Use callback if available (modern SpeechRecognizer approach), otherwise fallback to Activity
+                if (onSpeechRecognitionRequested != null) {
+                    onSpeechRecognitionRequested?.invoke()
+                } else {
+                    startSpeechRecognition(inputConnection)
+                }
+            }
+            microphoneButton.alpha = 1f
+            microphoneButton.visibility = View.VISIBLE
         }
-        microphoneButton.alpha = 1f
-        microphoneButton.visibility = View.VISIBLE
 
         // Language switch button (language code)
         val languageButton = languageButtonView ?: createLanguageButton(fixedButtonSize)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -42,6 +42,14 @@
     <!-- Auto Show Keyboard Section -->
     <string name="auto_show_keyboard_title">Tastatur automatisch anzeigen</string>
     
+    <!-- Alt+Ctrl Speech Recognition Shortcut Section -->
+    <string name="alt_ctrl_speech_shortcut_title">Alt+Ctrl Spracherkennung</string>
+    <string name="alt_ctrl_speech_shortcut_description">Alt+Ctrl Tastenkombination aktivieren, um Spracherkennung zu starten</string>
+
+    <!-- Show Voice Input Button Section -->
+    <string name="show_voice_input_button_title">Spracheingabe-Button anzeigen</string>
+    <string name="show_voice_input_button_description">Das Mikrofon-Symbol in der Eingabemethodenleiste für Spracheingabe anzeigen</string>
+    
     <!-- Info Section -->
     <string name="info_title">Informationen</string>
     <string name="info_description">Einstellungen werden automatisch gespeichert und sofort auf die Eingabemethode angewendet.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,10 @@
     <string name="alt_ctrl_speech_shortcut_title">Alt+Ctrl Speech Recognition</string>
     <string name="alt_ctrl_speech_shortcut_description">Enable Alt+Ctrl keyboard shortcut to start speech recognition</string>
 
+    <!-- Show Voice Input Button Section -->
+    <string name="show_voice_input_button_title">Show Voice Input Button</string>
+    <string name="show_voice_input_button_description">Display the microphone button in the input method bar for voice input</string>
+
     <!-- Static Variation Bar Mode -->
     <string name="static_variation_bar_mode_title">Static Variation Bar</string>
     <string name="static_variation_bar_mode_description">Always show a fixed set of utility keys in the variation row instead of context-based variations.</string>


### PR DESCRIPTION
Implements #51

Added a new setting 'Show Voice Input Button' in the Text Input settings screen that allows users to hide the microphone button from the input method bar if they don't use voice input.

Changes:
- Added getShowVoiceInputButton/setShowVoiceInputButton to SettingsManager
- Added toggle in TextInputSettingsScreen
- Modified VariationBarView to conditionally show microphone button
- Added strings in English and German (values/strings.xml, values-de/strings.xml)
- Default: enabled (preserves existing behavior)