### PR TITLE
feat: Add option to disable accented letter variations

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/AutoCorrectionCategoryScreen.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/AutoCorrectionCategoryScreen.kt
@@ -72,6 +72,9 @@ fun AutoCorrectionCategoryScreen(
     var useEditTypeRanking by remember {
         mutableStateOf(SettingsManager.getUseEditTypeRanking(context))
     }
+    var disableAccentedLetters by remember {
+        mutableStateOf(SettingsManager.isAccentedLettersDisabled(context))
+    }
     var navigationDirection by remember { mutableStateOf(LocalNavigationDirection.Push) }
     val navigationStack = remember {
         mutableStateListOf<AutoCorrectionDestination>(AutoCorrectionDestination.Main)
@@ -285,6 +288,49 @@ fun AutoCorrectionCategoryScreen(
                                     )
                                 }
                             }
+
+                        // Disable Accented Letters Toggle
+                        Surface(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(64.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.TextFields,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = stringResource(R.string.disable_accented_letters_title),
+                                        style = MaterialTheme.typography.titleMedium,
+                                        fontWeight = FontWeight.Medium,
+                                        maxLines = 1
+                                    )
+                                    Text(
+                                        text = stringResource(R.string.disable_accented_letters_description),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                                Switch(
+                                    checked = disableAccentedLetters,
+                                    onCheckedChange = { disabled ->
+                                        disableAccentedLetters = disabled
+                                        SettingsManager.setAccentedLettersDisabled(context, disabled)
+                                    },
+                                    enabled = experimentalSuggestionsEnabled
+                                )
+                            }
+                        }
 
                         Surface(
                             modifier = Modifier

--- a/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
@@ -52,6 +52,8 @@ object SettingsManager {
     private const val KEY_CLIPBOARD_RETENTION_TIME = "clipboard_retention_time" // How long to keep clipboard entries (in minutes)
     private const val KEY_TRACKPAD_GESTURES_ENABLED = "trackpad_gestures_enabled" // Whether trackpad gesture suggestions are enabled
     private const val KEY_TRACKPAD_SWIPE_THRESHOLD = "trackpad_swipe_threshold" // Threshold for swipe detection on trackpad
+    private const val KEY_SHOW_VOICE_INPUT_BUTTON = "show_voice_input_button" // Whether to show the voice input microphone button
+    private const val KEY_DISABLE_ACCENTED_LETTERS = "disable_accented_letters" // Whether to hide accented letter variations
 
     private const val VARIATIONS_FILE_NAME = "variations.json"
     
@@ -94,6 +96,8 @@ object SettingsManager {
     private const val DEFAULT_TRACKPAD_SWIPE_THRESHOLD = 300f
     private const val MIN_TRACKPAD_SWIPE_THRESHOLD = 120f
     private const val MAX_TRACKPAD_SWIPE_THRESHOLD = 600f
+    private const val DEFAULT_SHOW_VOICE_INPUT_BUTTON = true
+    private const val DEFAULT_DISABLE_ACCENTED_LETTERS = false
 
     /**
      * Returns the SharedPreferences instance for Pastiera.
@@ -303,6 +307,23 @@ object SettingsManager {
     fun setStaticVariationBarModeEnabled(context: Context, enabled: Boolean) {
         getPreferences(context).edit()
             .putBoolean(KEY_STATIC_VARIATION_BAR_MODE, enabled)
+            .apply()
+    }
+
+    /**
+     * Returns whether accented letter variations should be disabled.
+     * When enabled, the variation row will prioritize word suggestions over accented letters.
+     */
+    fun isAccentedLettersDisabled(context: Context): Boolean {
+        return getPreferences(context).getBoolean(KEY_DISABLE_ACCENTED_LETTERS, DEFAULT_DISABLE_ACCENTED_LETTERS)
+    }
+
+    /**
+     * Sets whether accented letter variations should be disabled.
+     */
+    fun setAccentedLettersDisabled(context: Context, disabled: Boolean) {
+        getPreferences(context).edit()
+            .putBoolean(KEY_DISABLE_ACCENTED_LETTERS, disabled)
             .apply()
     }
 
@@ -1581,6 +1602,26 @@ object SettingsManager {
     fun getMinTrackpadSwipeThreshold(): Float = MIN_TRACKPAD_SWIPE_THRESHOLD
     fun getMaxTrackpadSwipeThreshold(): Float = MAX_TRACKPAD_SWIPE_THRESHOLD
     fun getDefaultTrackpadSwipeThreshold(): Float = DEFAULT_TRACKPAD_SWIPE_THRESHOLD
+
+    /**
+     * Returns whether the voice input microphone button should be shown.
+     * @param context The context
+     * @return Whether the voice input button is enabled
+     */
+    fun getShowVoiceInputButton(context: Context): Boolean {
+        return getPreferences(context).getBoolean(KEY_SHOW_VOICE_INPUT_BUTTON, DEFAULT_SHOW_VOICE_INPUT_BUTTON)
+    }
+
+    /**
+     * Sets whether the voice input microphone button should be shown.
+     * @param context The context
+     * @param enabled Whether to show the voice input button
+     */
+    fun setShowVoiceInputButton(context: Context, enabled: Boolean) {
+        getPreferences(context).edit()
+            .putBoolean(KEY_SHOW_VOICE_INPUT_BUTTON, enabled)
+            .apply()
+    }
 
     /**
      * Returns the File for variations.json in filesDir.

--- a/app/src/main/java/it/palsoftware/pastiera/backup/BackupContract.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/backup/BackupContract.kt
@@ -222,6 +222,7 @@ object PreferenceSchemas {
             "trackpad_gestures_enabled" to PreferenceValueType.BOOLEAN,
             "trackpad_swipe_threshold" to PreferenceValueType.FLOAT,
             "use_keyboard_proximity" to PreferenceValueType.BOOLEAN,
+            "disable_accented_letters" to PreferenceValueType.BOOLEAN,
             "use_edit_type_ranking" to PreferenceValueType.BOOLEAN,
             "custom_input_styles" to PreferenceValueType.STRING
         ),

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/ui/VariationBarView.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/ui/VariationBarView.kt
@@ -399,19 +399,26 @@ class VariationBarView(
 
         // Decide whether to use suggestions, dynamic variations (from cursor) or static utility keys.
         val staticModeEnabled = SettingsManager.isStaticVariationBarModeEnabled(context)
+        val disableAccentedLetters = SettingsManager.isAccentedLettersDisabled(context)
         // Variations are controlled separately from suggestions
         val canShowVariations = !snapshot.shouldDisableVariations
         val canShowSuggestions = !snapshot.shouldDisableSuggestions
         // Legacy variations: always honor them when present, independent of suggestions.
-        val hasDynamicVariations = canShowVariations && snapshot.variations.isNotEmpty()
+        // But skip dynamic variations if accented letters are disabled
+        val hasDynamicVariations = !disableAccentedLetters && canShowVariations && snapshot.variations.isNotEmpty()
         val hasSuggestions = canShowSuggestions && snapshot.suggestions.isNotEmpty()
         val useDynamicVariations = !staticModeEnabled && hasDynamicVariations
         val allowStaticFallback = staticModeEnabled || snapshot.shouldDisableVariations
 
         val effectiveVariations: List<String>
         val isStaticContent: Boolean
-        // Legacy behavior: give priority to letter variations when available, otherwise suggestions.
+        // Priority: suggestions (if accented letters disabled), then letter variations, then suggestions, then static
         when {
+            disableAccentedLetters && hasSuggestions -> {
+                // When accented letters are disabled, prioritize suggestions
+                effectiveVariations = snapshot.suggestions
+                isStaticContent = false
+            }
             useDynamicVariations -> {
                 effectiveVariations = snapshot.variations
                 isStaticContent = false
@@ -592,24 +599,27 @@ class VariationBarView(
         val buttonsContainerView = buttonsContainer ?: return
         buttonsContainerView.removeAllViews()
         
-        val microphoneButton = microphoneButtonView ?: createMicrophoneButton(fixedButtonSize)
-        microphoneButtonView = microphoneButton
-        (microphoneButton.parent as? ViewGroup)?.removeView(microphoneButton)
-        val micParams = LinearLayout.LayoutParams(fixedButtonSize, fixedButtonSize).apply {
-            marginStart = spacingBetweenButtons
-        }
-        buttonsContainerView.addView(microphoneButton, micParams)
-        microphoneButton.setOnClickListener {
-            NotificationHelper.triggerHapticFeedback(context)
-            // Use callback if available (modern SpeechRecognizer approach), otherwise fallback to Activity
-            if (onSpeechRecognitionRequested != null) {
-                onSpeechRecognitionRequested?.invoke()
-            } else {
-                startSpeechRecognition(inputConnection)
+        // Only add microphone button if the setting is enabled
+        if (SettingsManager.getShowVoiceInputButton(context)) {
+            val microphoneButton = microphoneButtonView ?: createMicrophoneButton(fixedButtonSize)
+            microphoneButtonView = microphoneButton
+            (microphoneButton.parent as? ViewGroup)?.removeView(microphoneButton)
+            val micParams = LinearLayout.LayoutParams(fixedButtonSize, fixedButtonSize).apply {
+                marginStart = spacingBetweenButtons
             }
+            buttonsContainerView.addView(microphoneButton, micParams)
+            microphoneButton.setOnClickListener {
+                NotificationHelper.triggerHapticFeedback(context)
+                // Use callback if available (modern SpeechRecognizer approach), otherwise fallback to Activity
+                if (onSpeechRecognitionRequested != null) {
+                    onSpeechRecognitionRequested?.invoke()
+                } else {
+                    startSpeechRecognition(inputConnection)
+                }
+            }
+            microphoneButton.alpha = 1f
+            microphoneButton.visibility = View.VISIBLE
         }
-        microphoneButton.alpha = 1f
-        microphoneButton.visibility = View.VISIBLE
 
         // Language switch button (language code)
         val languageButton = languageButtonView ?: createLanguageButton(fixedButtonSize)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -42,6 +42,14 @@
     <!-- Auto Show Keyboard Section -->
     <string name="auto_show_keyboard_title">Tastatur automatisch anzeigen</string>
     
+    <!-- Alt+Ctrl Speech Recognition Shortcut Section -->
+    <string name="alt_ctrl_speech_shortcut_title">Alt+Ctrl Spracherkennung</string>
+    <string name="alt_ctrl_speech_shortcut_description">Alt+Ctrl Tastenkombination aktivieren, um Spracherkennung zu starten</string>
+
+    <!-- Show Voice Input Button Section -->
+    <string name="show_voice_input_button_title">Spracheingabe-Button anzeigen</string>
+    <string name="show_voice_input_button_description">Das Mikrofon-Symbol in der Eingabemethodenleiste für Spracheingabe anzeigen</string>
+    
     <!-- Info Section -->
     <string name="info_title">Informationen</string>
     <string name="info_description">Einstellungen werden automatisch gespeichert und sofort auf die Eingabemethode angewendet.</string>
@@ -278,6 +286,10 @@
     <!-- Static Variation Bar Mode -->
     <string name="static_variation_bar_mode_title">Statische Variationsleiste</string>
     <string name="static_variation_bar_mode_description">Immer einen festen Satz von Hilfstasten in der Variationszeile anzeigen anstelle von kontextbasierten Variationen.</string>
+
+    <!-- Disable Accented Letters -->
+    <string name="disable_accented_letters_title">Akzentuierte Buchstaben ausblenden</string>
+    <string name="disable_accented_letters_description">Buchstaben-Variationen (ä, ö, ü) verstecken, um nur Wortvorhersagen anzuzeigen</string>
     
     <!-- SYM Customization Screen -->
     <string name="sym_tab_emoji">Emoji</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -277,6 +277,10 @@
     <!-- Static Variation Bar Mode -->
     <string name="static_variation_bar_mode_title">Barra de variaciones estática</string>
     <string name="static_variation_bar_mode_description">Mostrar siempre un conjunto fijo de teclas de utilidad en la fila de variaciones en lugar de variaciones contextuales.</string>
+
+    <!-- Disable Accented Letters -->
+    <string name="disable_accented_letters_title">Desactivar letras acentuadas</string>
+    <string name="disable_accented_letters_description">Ocultar las variaciones de letras acentuadas (á, é, í, ó, ú) para mostrar solo predicciones de palabras</string>
     
     <!-- SYM Customization Screen -->
     <string name="sym_tab_emoji">Emoji</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -279,6 +279,10 @@
     <!-- Static Variation Bar Mode -->
     <string name="static_variation_bar_mode_title">Barre de variations statique</string>
     <string name="static_variation_bar_mode_description">Toujours afficher un ensemble fixe de touches utilitaires dans la barre de variations au lieu des variations contextuelles.</string>
+
+    <!-- Disable Accented Letters -->
+    <string name="disable_accented_letters_title">Désactiver les lettres accentuées</string>
+    <string name="disable_accented_letters_description">Masquer les variations de lettres accentuées (à, é, è, ù) pour afficher uniquement les prédictions de mots</string>
     
     <!-- SYM Customization Screen -->
     <string name="sym_tab_emoji">Emoji</string>

--- a/app/src/main/res/values-hy/strings.xml
+++ b/app/src/main/res/values-hy/strings.xml
@@ -322,5 +322,9 @@
     <string name="installed_dictionaries_import_invalid_format">Բառարանի ձևաչափը սխալ է</string>
     <string name="installed_dictionaries_import_failed">Ներմուծումը ձախողվեց</string>
     <string name="installed_dictionaries_imported_badge">Ներմուծված</string>
+
+    <!-- Disable Accented Letters -->
+    <string name="disable_accented_letters_title">Անջատել շեշտավոր տառերը</string>
+    <string name="disable_accented_letters_description">Թաքցնել շեշտավոր տառերի տարբերակները՝ ցույց տալու միայն բառերի կանխատեսումները</string>
 </resources>
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -259,6 +259,10 @@
     <!-- Static Variation Bar Mode -->
     <string name="static_variation_bar_mode_title">Barra variazioni statica</string>
     <string name="static_variation_bar_mode_description">Mostra sempre una serie fissa di tasti di utilità nella barra variazioni invece delle variazioni contestuali.</string>
+
+    <!-- Disable Accented Letters -->
+    <string name="disable_accented_letters_title">Disabilita lettere accentate</string>
+    <string name="disable_accented_letters_description">Nascondi le variazioni di lettere accentate (à, è, ì, ò, ù) per mostrare solo le previsioni di parole</string>
     
     <!-- Auto Correct Edit Screen -->
     <string name="auto_correct_search_placeholder">Cerca correzioni...</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -277,6 +277,10 @@
     <!-- Static Variation Bar Mode -->
     <string name="static_variation_bar_mode_title">Statyczny pasek wariantów</string>
     <string name="static_variation_bar_mode_description">Zawsze wyświetlaj stały zestaw klawiszy narzędziowych w rzędzie wariantów zamiast wariantów kontekstowych.</string>
+
+    <!-- Disable Accented Letters -->
+    <string name="disable_accented_letters_title">Wyłącz litery akcentowane</string>
+    <string name="disable_accented_letters_description">Ukryj warianty liter akcentowanych (ą, ć, ę, ł, ń, ó, ś, ź, ż), aby pokazywać tylko przewidywania słów</string>
     
     <!-- SYM Customization Screen -->
     <string name="sym_tab_emoji">Emoji</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -288,6 +288,10 @@
     <string name="update_dialog_open_github">Открыть GitHub</string>
     <string name="update_dialog_later">Позже</string>
     <string name="update_dialog_download_apk">Скачать APK</string>
+
+    <!-- Disable Accented Letters -->
+    <string name="disable_accented_letters_title">Отключить буквы с акцентами</string>
+    <string name="disable_accented_letters_description">Скрыть варианты букв с акцентами, чтобы показывать только предсказания слов</string>
     
     <!-- Custom Input Styles -->
     <string name="custom_input_styles_title">Языки и раскладки</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,10 +52,18 @@
     <string name="alt_ctrl_speech_shortcut_title">Alt+Ctrl Speech Recognition</string>
     <string name="alt_ctrl_speech_shortcut_description">Enable Alt+Ctrl keyboard shortcut to start speech recognition</string>
 
+    <!-- Show Voice Input Button Section -->
+    <string name="show_voice_input_button_title">Show Voice Input Button</string>
+    <string name="show_voice_input_button_description">Display the microphone button in the input method bar for voice input</string>
+
     <!-- Static Variation Bar Mode -->
     <string name="static_variation_bar_mode_title">Static Variation Bar</string>
     <string name="static_variation_bar_mode_description">Always show a fixed set of utility keys in the variation row instead of context-based variations.</string>
     <string name="swipe_to_move_cursor">Swipe to move cursor</string>
+
+    <!-- Disable Accented Letters -->
+    <string name="disable_accented_letters_title">Disable Accented Letters</string>
+    <string name="disable_accented_letters_description">Hide accented letter variations (ä, ö, ü) to show only word predictions</string>
     
     <!-- Info Section -->
     <string name="info_title">Information</string>


### PR DESCRIPTION
- Add new setting 'Disable Accented Letters' in AutoCorrection settings
- When enabled, variation bar shows only word predictions instead of accented letters (ä, ö, ü)
- Improves trackpad swipe-up gesture usability with 3 clear suggestion areas
- Perfect for English users who don't need accented letters
- Translations added for all supported languages (DE, IT, FR, ES, PL, RU, HY)
- Backup support included

Implements GitHub issue #66