### PR TITLE
feat: Add alternative delete methods for Backspace key

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
@@ -52,6 +52,8 @@ object SettingsManager {
     private const val KEY_CLIPBOARD_RETENTION_TIME = "clipboard_retention_time" // How long to keep clipboard entries (in minutes)
     private const val KEY_TRACKPAD_GESTURES_ENABLED = "trackpad_gestures_enabled" // Whether trackpad gesture suggestions are enabled
     private const val KEY_TRACKPAD_SWIPE_THRESHOLD = "trackpad_swipe_threshold" // Threshold for swipe detection on trackpad
+    private const val KEY_SHIFT_BACKSPACE_DELETE = "shift_backspace_delete" // Shift + Backspace performs forward delete
+    private const val KEY_BACKSPACE_AT_START_DELETE = "backspace_at_start_delete" // Backspace at line start performs forward delete
 
     private const val VARIATIONS_FILE_NAME = "variations.json"
     
@@ -94,6 +96,8 @@ object SettingsManager {
     private const val DEFAULT_TRACKPAD_SWIPE_THRESHOLD = 300f
     private const val MIN_TRACKPAD_SWIPE_THRESHOLD = 120f
     private const val MAX_TRACKPAD_SWIPE_THRESHOLD = 600f
+    private const val DEFAULT_SHIFT_BACKSPACE_DELETE = false
+    private const val DEFAULT_BACKSPACE_AT_START_DELETE = false
 
     /**
      * Returns the SharedPreferences instance for Pastiera.
@@ -253,6 +257,38 @@ object SettingsManager {
     fun setSwipeToDelete(context: Context, enabled: Boolean) {
         getPreferences(context).edit()
             .putBoolean(KEY_SWIPE_TO_DELETE, enabled)
+            .apply()
+    }
+    
+    /**
+     * Returns whether Shift+Backspace performs forward delete.
+     */
+    fun getShiftBackspaceDelete(context: Context): Boolean {
+        return getPreferences(context).getBoolean(KEY_SHIFT_BACKSPACE_DELETE, DEFAULT_SHIFT_BACKSPACE_DELETE)
+    }
+    
+    /**
+     * Sets whether Shift+Backspace performs forward delete.
+     */
+    fun setShiftBackspaceDelete(context: Context, enabled: Boolean) {
+        getPreferences(context).edit()
+            .putBoolean(KEY_SHIFT_BACKSPACE_DELETE, enabled)
+            .apply()
+    }
+    
+    /**
+     * Returns whether Backspace at line start performs forward delete.
+     */
+    fun getBackspaceAtStartDelete(context: Context): Boolean {
+        return getPreferences(context).getBoolean(KEY_BACKSPACE_AT_START_DELETE, DEFAULT_BACKSPACE_AT_START_DELETE)
+    }
+    
+    /**
+     * Sets whether Backspace at line start performs forward delete.
+     */
+    fun setBackspaceAtStartDelete(context: Context, enabled: Boolean) {
+        getPreferences(context).edit()
+            .putBoolean(KEY_BACKSPACE_AT_START_DELETE, enabled)
             .apply()
     }
     

--- a/app/src/main/java/it/palsoftware/pastiera/TextInputSettingsScreen.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/TextInputSettingsScreen.kt
@@ -60,6 +60,14 @@ fun TextInputSettingsScreen(
         mutableStateOf(SettingsManager.getAltCtrlSpeechShortcutEnabled(context))
     }
     
+    var shiftBackspaceDelete by remember {
+        mutableStateOf(SettingsManager.getShiftBackspaceDelete(context))
+    }
+    
+    var backspaceAtStartDelete by remember {
+        mutableStateOf(SettingsManager.getBackspaceAtStartDelete(context))
+    }
+    
     // Handle system back button
     BackHandler { onBack() }
     
@@ -381,6 +389,91 @@ fun TextInputSettingsScreen(
                     )
                 }
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Delete Alternatives Section
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                tonalElevation = 2.dp,
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.delete_alternatives_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(R.string.delete_alternatives_description),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    
+                    Spacer(modifier = Modifier.height(16.dp))
+                    
+                    // Shift + Backspace option
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = stringResource(R.string.shift_backspace_delete_title),
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Switch(
+                            checked = shiftBackspaceDelete,
+                            onCheckedChange = { enabled ->
+                                shiftBackspaceDelete = enabled
+                                SettingsManager.setShiftBackspaceDelete(context, enabled)
+                            }
+                        )
+                    }
+                    
+                    Spacer(modifier = Modifier.height(12.dp))
+                    
+                    // Backspace at start option
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = stringResource(R.string.backspace_at_start_delete_title),
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Switch(
+                            checked = backspaceAtStartDelete,
+                            onCheckedChange = { enabled ->
+                                backspaceAtStartDelete = enabled
+                                SettingsManager.setBackspaceAtStartDelete(context, enabled)
+                            }
+                        )
+                    }
+                    
+                    Spacer(modifier = Modifier.height(12.dp))
+                    
+                    // Hint text
+                    Text(
+                        text = stringResource(R.string.delete_alternatives_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontStyle = androidx.compose.ui.text.font.FontStyle.Italic
+                    )
+                }
+            }
+            
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/InputEventRouter.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/InputEventRouter.kt
@@ -650,6 +650,25 @@ class InputEventRouter(
             handleInWordApostrophe(inputConnection, pendingApostrophe = true)
         }
 
+        // Handle Shift+Backspace → Delete (if enabled)
+        if (keyCode == KeyEvent.KEYCODE_DEL && event?.isShiftPressed == true) {
+            if (SettingsManager.getShiftBackspaceDelete(context)) {
+                inputConnection?.deleteSurroundingText(0, 1)
+                return true
+            }
+        }
+
+        // Handle Backspace at start → Delete (if enabled)
+        if (keyCode == KeyEvent.KEYCODE_DEL && event?.isShiftPressed != true) {
+            if (SettingsManager.getBackspaceAtStartDelete(context)) {
+                val textBefore = inputConnection?.getTextBeforeCursor(1, 0)
+                if (textBefore?.isEmpty() == true) {
+                    inputConnection.deleteSurroundingText(0, 1)
+                    return true
+                }
+            }
+        }
+
         // Clear pending auto-space flag on backspace (avoid stale state); keep it for letters to handle long-press punctuation.
         if (typedChar == null && keyCode == KeyEvent.KEYCODE_DEL) {
             AutoSpaceTracker.clear()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -39,6 +39,13 @@
     <!-- Swipe to Delete Section -->
     <string name="swipe_to_delete_title">Wischen zum Löschen aktivieren</string>
     
+    <!-- Delete Alternatives Section -->
+    <string name="delete_alternatives_title">Entfernen</string>
+    <string name="delete_alternatives_description">Alternative Methoden zum Entfernen von Zeichen rechts vom Cursor</string>
+    <string name="shift_backspace_delete_title">Shift + Backspace</string>
+    <string name="backspace_at_start_delete_title">Backspace am Zeilenstart</string>
+    <string name="delete_alternatives_hint">Hinweis: Ctrl + Taste kann in den Nav-Mode-Einstellungen konfiguriert werden</string>
+    
     <!-- Auto Show Keyboard Section -->
     <string name="auto_show_keyboard_title">Tastatur automatisch anzeigen</string>
     

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -38,6 +38,13 @@
     <!-- Swipe to Delete Section -->
     <string name="swipe_to_delete_title">Activar Deslizar para Eliminar</string>
     
+    <!-- Delete Alternatives Section -->
+    <string name="delete_alternatives_title">Eliminar</string>
+    <string name="delete_alternatives_description">Métodos alternativos para eliminar caracteres a la derecha del cursor</string>
+    <string name="shift_backspace_delete_title">Shift + Backspace</string>
+    <string name="backspace_at_start_delete_title">Backspace al inicio de línea</string>
+    <string name="delete_alternatives_hint">Nota: Ctrl + tecla se puede configurar en los ajustes de Nav Mode</string>
+    
     <!-- Auto Show Keyboard Section -->
     <string name="auto_show_keyboard_title">Mostrar Automáticamente el Teclado</string>
     

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -38,6 +38,13 @@
     <!-- Swipe to Delete Section -->
     <string name="swipe_to_delete_title">Balayer pour supprimer</string>
     
+    <!-- Delete Alternatives Section -->
+    <string name="delete_alternatives_title">Supprimer</string>
+    <string name="delete_alternatives_description">Méthodes alternatives pour supprimer des caractères à droite du curseur</string>
+    <string name="shift_backspace_delete_title">Shift + Backspace</string>
+    <string name="backspace_at_start_delete_title">Backspace au début de ligne</string>
+    <string name="delete_alternatives_hint">Note : Ctrl + touche peut être configuré dans les paramètres Nav Mode</string>
+    
     <!-- Auto Show Keyboard Section -->
     <string name="auto_show_keyboard_title">Afficher Automatiquement le Clavier</string>
     

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -39,6 +39,13 @@
     <!-- Swipe to Delete Section -->
     <string name="swipe_to_delete_title">Abilita Swipe per Cancellare</string>
     
+    <!-- Delete Alternatives Section -->
+    <string name="delete_alternatives_title">Elimina</string>
+    <string name="delete_alternatives_description">Metodi alternativi per eliminare caratteri a destra del cursore</string>
+    <string name="shift_backspace_delete_title">Shift + Backspace</string>
+    <string name="backspace_at_start_delete_title">Backspace all\'inizio della riga</string>
+    <string name="delete_alternatives_hint">Nota: Ctrl + tasto può essere configurato nelle impostazioni Nav Mode</string>
+    
     <!-- Swipe Incremental Threshold Section -->
     <string name="swipe_incremental_threshold_title">Sensibilità Swipe Bar</string>
     <string name="swipe_to_move_cursor">Swipe per spostare il cursore</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -38,6 +38,13 @@
     <!-- Swipe to Delete Section -->
     <string name="swipe_to_delete_title">Włącz Przesunięcie do Usunięcia</string>
     
+    <!-- Delete Alternatives Section -->
+    <string name="delete_alternatives_title">Usuń</string>
+    <string name="delete_alternatives_description">Alternatywne metody usuwania znaków po prawej stronie kursora</string>
+    <string name="shift_backspace_delete_title">Shift + Backspace</string>
+    <string name="backspace_at_start_delete_title">Backspace na początku linii</string>
+    <string name="delete_alternatives_hint">Uwaga: Ctrl + klawisz można skonfigurować w ustawieniach Nav Mode</string>
+    
     <!-- Auto Show Keyboard Section -->
     <string name="auto_show_keyboard_title">Automatycznie Pokaż Klawiaturę</string>
     

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,13 @@
     <!-- Swipe to Delete Section -->
     <string name="swipe_to_delete_title">Enable Swipe to Delete</string>
     
+    <!-- Delete Alternatives Section -->
+    <string name="delete_alternatives_title">Delete</string>
+    <string name="delete_alternatives_description">Alternative methods to delete characters to the right of cursor</string>
+    <string name="shift_backspace_delete_title">Shift + Backspace</string>
+    <string name="backspace_at_start_delete_title">Backspace at line start</string>
+    <string name="delete_alternatives_hint">Hint: Ctrl + key can be configured in Nav Mode settings</string>
+    
     <!-- Swipe Incremental Threshold Section -->
     <string name="swipe_incremental_threshold_title">Swipe Bar Sensitivity</string>
     <string name="swipe_incremental_threshold_description">Distance required to move cursor one position. Lower values make the cursor move faster.</string>


### PR DESCRIPTION
Add configurable options to delete characters to the right of the cursor:

- Shift + Backspace: Forward delete when Shift is held
- Backspace at line start: Forward delete when cursor is at the beginning of the line

These options complement the existing Ctrl+Key configuration available in Nav Mode settings.

Changes:
- Add settings keys and getters/setters in SettingsManager
- Implement Delete Alternatives UI section in TextInputSettingsScreen
- Add input handling logic in InputEventRouter
- Add localized strings for German, English, Italian, French, Spanish, and Polish

Fixes #50