### PR TITLE
Key2 series mapping on LineageOS

### DIFF
--- a/app/src/main/assets/devices/key2/alt_key_mappings.json
+++ b/app/src/main/assets/devices/key2/alt_key_mappings.json
@@ -1,0 +1,30 @@
+{
+  "mappings": {
+    "KEYCODE_Q": "#",
+    "KEYCODE_W": "1",
+    "KEYCODE_E": "2",
+    "KEYCODE_R": "3",
+    "KEYCODE_T": "(",
+    "KEYCODE_Y": ")",
+    "KEYCODE_U": "_",
+    "KEYCODE_I": "-",
+    "KEYCODE_O": "+",
+    "KEYCODE_P": "@",
+    "KEYCODE_A": "*",
+    "KEYCODE_S": "4",
+    "KEYCODE_D": "5",
+    "KEYCODE_F": "6",
+    "KEYCODE_G": "/",
+    "KEYCODE_H": ":",
+    "KEYCODE_J": ";",
+    "KEYCODE_K": ",",
+    "KEYCODE_L": "\"",
+    "KEYCODE_Z": "7",
+    "KEYCODE_X": "8",
+    "KEYCODE_C": "9",
+    "KEYCODE_V": "?",
+    "KEYCODE_B": "!",
+    "KEYCODE_N": ",",
+    "KEYCODE_M": "."
+  }
+}

--- a/app/src/main/assets/devices/key2/alt_key_mappings.json
+++ b/app/src/main/assets/devices/key2/alt_key_mappings.json
@@ -17,7 +17,7 @@
     "KEYCODE_G": "/",
     "KEYCODE_H": ":",
     "KEYCODE_J": ";",
-    "KEYCODE_K": ",",
+    "KEYCODE_K": "'",
     "KEYCODE_L": "\"",
     "KEYCODE_Z": "7",
     "KEYCODE_X": "8",

--- a/app/src/main/java/it/palsoftware/pastiera/data/mappings/KeyMappingLoader.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/data/mappings/KeyMappingLoader.kt
@@ -2,6 +2,7 @@ package it.palsoftware.pastiera.data.mappings
 
 import android.content.Context
 import android.content.res.AssetManager
+import android.os.Build
 import android.util.Log
 import android.view.KeyEvent
 import it.palsoftware.pastiera.SettingsManager
@@ -15,6 +16,14 @@ object KeyMappingLoader {
     private const val TAG = "KeyMappingLoader"
 
     fun getDeviceName(context: Context? = null): String {
+        val codename = Build.DEVICE
+
+        // both Key2 variants share the same PKB layout
+        // under LineageOS
+        if (codename == "athena" || codename == "luna") {
+            return "key2"
+        }
+
         return "titan2"
     }
 


### PR DESCRIPTION
Hi,

short PR which allows proper mapping of alt-keys on BlackBerry Key2 devices running LineageOS 22.2 builds. Keyboard works perfectly with this patch applied. Shouldn't break titan2.

Regards :)