### PR TITLE
feat: allow space, enter, and backspace shortcut keys

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/LauncherShortcutsScreen.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/LauncherShortcutsScreen.kt
@@ -172,8 +172,8 @@ fun LauncherShortcutsScreen(
         // Griglia QWERTY con larghezza fissa (come SYM layers)
         val qwertyRows = listOf(
             listOf("Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P"),
-            listOf("A", "S", "D", "F", "G", "H", "J", "K", "L"),
-            listOf("Z", "X", "C", "V", "B", "N", "M")
+            listOf("A", "S", "D", "F", "G", "H", "J", "K", "L", "⌫"),
+            listOf("Z", "X", "C", "V","␣", "B", "N", "M", "⏎")
         )
         
         // Funzione helper per ottenere l'icona dell'app
@@ -192,7 +192,7 @@ fun LauncherShortcutsScreen(
         BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = 8.dp)
                 .onGloballyPositioned { coordinates ->
                     val position = coordinates.positionInRoot()
                     containerPosition = position
@@ -201,7 +201,7 @@ fun LauncherShortcutsScreen(
             val density = LocalDensity.current
             // Calcola la larghezza fissa per ogni tasto (come nella visuale SYM)
             val maxKeysInRow = qwertyRows.maxOf { it.size }
-            val keySpacing = 8.dp
+            val keySpacing = 4.dp
             val totalSpacing = keySpacing * (maxKeysInRow - 1)
             val availableWidth = maxWidth - totalSpacing
             val fixedKeyWidth = availableWidth / maxKeysInRow
@@ -209,7 +209,7 @@ fun LauncherShortcutsScreen(
             
             Column(
                 modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(keySpacing)
             ) {
                 qwertyRows.forEachIndexed { rowIndex, row ->
                     // Calcola lo spazio necessario per centrare la riga
@@ -255,6 +255,9 @@ fun LauncherShortcutsScreen(
                                 "B" -> KeyEvent.KEYCODE_B
                                 "N" -> KeyEvent.KEYCODE_N
                                 "M" -> KeyEvent.KEYCODE_M
+                                "⌫" -> KeyEvent.KEYCODE_DEL
+                                "␣" -> KeyEvent.KEYCODE_SPACE
+                                "⏎" -> KeyEvent.KEYCODE_ENTER
                                 else -> null
                             }
                             
@@ -477,7 +480,7 @@ fun LauncherShortcutsScreen(
                                                 // Mostra la lettera del tasto
                                                 Text(
                                                     text = keyName,
-                                                    style = MaterialTheme.typography.titleLarge,
+                                                    style = MaterialTheme.typography.bodyLarge,
                                                     fontWeight = FontWeight.Bold,
                                                     color = if (hasApp) {
                                                         MaterialTheme.colorScheme.onPrimaryContainer
@@ -500,12 +503,11 @@ fun LauncherShortcutsScreen(
                 }
             }
             
-            // Trash icon positioned absolutely: right aligned, positioned lower
-            // Calculate horizontal position: align right with same padding as keyboard (16.dp), shifted left a bit
-            val keyboardPadding = 16.dp
-            val trashX = maxWidth - keyboardPadding - keySize - 9.dp
-            // Calculate vertical position: start of third row (moved down half key from previous position)
-            val trashY = keySize * 2 + keySpacing * 2
+            // Trash icon positioned absolutely: center aligned, positioned under keys
+            val trashX = (maxWidth - keySize) / 2
+            // Calculate vertical position: moved down third row
+            val rowsCount = 3
+            val trashY = keySize * rowsCount + keySpacing * rowsCount
             
             Box(
                 modifier = Modifier.fillMaxSize()
@@ -520,7 +522,7 @@ fun LauncherShortcutsScreen(
                         pos.y <= rect.bottom
                     } ?: false
                 } ?: false
-                
+
                 Surface(
                     modifier = Modifier
                         .width(keySize)

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/InputEventRouter.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/InputEventRouter.kt
@@ -12,15 +12,12 @@ import it.palsoftware.pastiera.core.NavModeController
 import it.palsoftware.pastiera.data.mappings.KeyMappingLoader
 import android.os.Handler
 import android.os.Looper
-import it.palsoftware.pastiera.inputmethod.AltSymManager
 import it.palsoftware.pastiera.core.SymLayoutController
 import it.palsoftware.pastiera.core.SymLayoutController.SymKeyResult
 import it.palsoftware.pastiera.core.TextInputController
 import it.palsoftware.pastiera.core.AutoCorrectionManager
 import it.palsoftware.pastiera.core.ModifierStateController
 import it.palsoftware.pastiera.core.AutoSpaceTracker
-import it.palsoftware.pastiera.inputmethod.KeyboardEventTracker
-import it.palsoftware.pastiera.inputmethod.TextSelectionHelper
 import android.view.inputmethod.ExtractedText
 import android.view.inputmethod.ExtractedTextRequest
 import it.palsoftware.pastiera.data.layout.LayoutMapping
@@ -87,7 +84,7 @@ class InputEventRouter(
     }
 
     data class NoEditableFieldCallbacks(
-        val isAlphabeticKey: (Int) -> Boolean,
+        val isShortcutKey: (Int) -> Boolean,
         val isLauncherPackage: (String?) -> Boolean,
         val handleLauncherShortcut: (Int) -> Boolean,
         val handlePowerShortcut: (Int) -> Boolean,
@@ -135,7 +132,7 @@ class InputEventRouter(
 
         // Gestisci Power Shortcuts (SYM premuto + tasto alfabetico)
         if (!ctrlLatchActive && powerShortcutsEnabled) {
-            if (callbacks.isAlphabeticKey(keyCode)) {
+            if (callbacks.isShortcutKey(keyCode)) {
                 if (callbacks.handlePowerShortcut(keyCode)) {
                     return true
                 }
@@ -145,7 +142,7 @@ class InputEventRouter(
         // Launcher Shortcuts (logica esistente - mantieni per compatibilità)
         if (!ctrlLatchActive && SettingsManager.getLauncherShortcutsEnabled(context)) {
             val packageName = editorInfo?.packageName ?: currentPackageName
-            if (callbacks.isLauncherPackage(packageName) && callbacks.isAlphabeticKey(keyCode)) {
+            if (callbacks.isLauncherPackage(packageName) && callbacks.isShortcutKey(keyCode)) {
                 if (callbacks.handleLauncherShortcut(keyCode)) {
                     return true
                 }

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/LauncherShortcutAssignmentActivity.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/LauncherShortcutAssignmentActivity.kt
@@ -270,6 +270,9 @@ private fun LauncherShortcutAssignmentBottomSheet(
             KeyEvent.KEYCODE_B -> "B"
             KeyEvent.KEYCODE_N -> "N"
             KeyEvent.KEYCODE_M -> "M"
+            KeyEvent.KEYCODE_DEL -> "⌫"
+            KeyEvent.KEYCODE_SPACE -> "␣"
+            KeyEvent.KEYCODE_ENTER -> "⏎"
             else -> null
         }
         return keyName ?: stringResource(R.string.launcher_shortcut_assignment_key_name, keyCode)

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
@@ -690,7 +690,14 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
             else -> false
         }
     }
-    
+
+    private fun isShortcutKey(keyCode: Int): Boolean =
+        isAlphabeticKey(keyCode) ||
+                keyCode == KeyEvent.KEYCODE_ENTER ||
+                keyCode == KeyEvent.KEYCODE_DEL ||
+                keyCode == KeyEvent.KEYCODE_SPACE
+
+
     override fun onCreate() {
         super.onCreate()
         prefs = getSharedPreferences("pastiera_prefs", Context.MODE_PRIVATE)
@@ -2022,7 +2029,7 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
                 event = event,
                 ctrlKeyMap = ctrlKeyMap,
                 callbacks = InputEventRouter.NoEditableFieldCallbacks(
-                    isAlphabeticKey = { code -> isAlphabeticKey(code) },
+                    isShortcutKey = { code -> isShortcutKey(code) },
                     isLauncherPackage = { pkg -> launcherShortcutController.isLauncher(pkg) },
                     handleLauncherShortcut = { key -> launcherShortcutController.handleLauncherShortcut(key) },
                     handlePowerShortcut = { key -> launcherShortcutController.handlePowerShortcut(key) },
@@ -2225,7 +2232,7 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
                 event = event,
                 ctrlKeyMap = ctrlKeyMap,
                 callbacks = InputEventRouter.NoEditableFieldCallbacks(
-                    isAlphabeticKey = { code -> isAlphabeticKey(code) },
+                    isShortcutKey = { code -> isShortcutKey(code) },
                     isLauncherPackage = { pkg -> launcherShortcutController.isLauncher(pkg) },
                     handleLauncherShortcut = { key -> launcherShortcutController.handleLauncherShortcut(key) },
                     handlePowerShortcut = { key -> launcherShortcutController.handlePowerShortcut(key) },


### PR DESCRIPTION
This PR adds Space, Enter, and Backspace to the Shortcuts settings and allows KEYCODE_SPACE, KEYCODE_ENTER, and KEYCODE_DEL to be used as valid shortcut keys.

This expands available shortcut options without altering existing bindings or behavior. I think the spacebar is an especially useful shortcut since it’s centrally located and easily reachable with both hands.

<img width="638" height="640" alt="image" src="https://github.com/user-attachments/assets/808698fe-79f5-4b0c-80f6-aa7f3e879e55" />

