### PR TITLE
Fix: Keyboard bottom clipping issue (Fixes #86, #89)

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/StatusBarController.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/StatusBarController.kt
@@ -314,16 +314,18 @@ class StatusBarController(
             statusBarLayout?.let { layout ->
                 baseBottomPadding = layout.paddingBottom
                 ViewCompat.setOnApplyWindowInsetsListener(layout) { view, insets ->
-                    // Preserve space for the system IME switcher / nav bar while keeping zero extra gap otherwise
-                    val navInsets = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-                    val imeInsets = insets.getInsets(WindowInsetsCompat.Type.ime())
+                    // Use getInsetsIgnoringVisibility to get stable insets for navigation and gesture areas
+                    // We should NOT include IME insets as that would add padding when the keyboard itself is shown
+                    val navAndGestures = insets.getInsetsIgnoringVisibility(
+                        WindowInsetsCompat.Type.navigationBars() or WindowInsetsCompat.Type.systemGestures()
+                    )
                     val cutout = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
-                    val bottomInset = maxOf(navInsets.bottom, imeInsets.bottom, cutout.bottom)
+                    val bottomInset = max(navAndGestures.bottom, cutout.bottom)
                     val appliedBottomPadding = baseBottomPadding + bottomInset
                     view.updatePadding(bottom = appliedBottomPadding)
                     logImeOverlayInsetsIfEnabled(
-                        navBottom = navInsets.bottom,
-                        imeBottom = imeInsets.bottom,
+                        navBottom = navAndGestures.bottom,
+                        imeBottom = 0,
                         cutoutBottom = cutout.bottom,
                         bottomInset = bottomInset,
                         appliedBottomPadding = appliedBottomPadding


### PR DESCRIPTION
The problem was introduced in commit 776ef87 where the window insets logic was changed to include IME insets. This caused the keyboard to add padding for itself, creating an unwanted gap/overlap at the bottom.

Changes:
- Reverted to using getInsetsIgnoringVisibility() for navigation bars and system gestures
- Removed IME insets from the bottom padding calculation
- This ensures the keyboard only reserves space for the system navigation bar and display cutouts

The fix has been tested with a successful debug build.