### PR TITLE
feat(layout): add German QWERTZ multi-tap layout

### DIFF
--- a/app/src/main/assets/common/layouts/german_multitap_qwertz.json
+++ b/app/src/main/assets/common/layouts/german_multitap_qwertz.json
@@ -1,0 +1,64 @@
+{
+  "name": "German (QWERTZ, multi-tap)",
+  "description": "QWERTZ layout with multi-tap access to German umlauts and Eszett.",
+  "mappings": {
+    "KEYCODE_Q": { "lowercase": "q", "uppercase": "Q" },
+    "KEYCODE_W": { "lowercase": "w", "uppercase": "W" },
+    "KEYCODE_E": { "lowercase": "e", "uppercase": "E" },
+    "KEYCODE_R": { "lowercase": "r", "uppercase": "R" },
+    "KEYCODE_T": { "lowercase": "t", "uppercase": "T" },
+    "KEYCODE_Y": { "lowercase": "z", "uppercase": "Z" },
+    "KEYCODE_U": {
+      "lowercase": "u",
+      "uppercase": "U",
+      "multiTapEnabled": true,
+      "taps": [
+        { "lowercase": "u", "uppercase": "U" },
+        { "lowercase": "ü", "uppercase": "Ü" }
+      ]
+    },
+    "KEYCODE_I": { "lowercase": "i", "uppercase": "I" },
+    "KEYCODE_O": {
+      "lowercase": "o",
+      "uppercase": "O",
+      "multiTapEnabled": true,
+      "taps": [
+        { "lowercase": "o", "uppercase": "O" },
+        { "lowercase": "ö", "uppercase": "Ö" }
+      ]
+    },
+    "KEYCODE_P": { "lowercase": "p", "uppercase": "P" },
+    "KEYCODE_A": {
+      "lowercase": "a",
+      "uppercase": "A",
+      "multiTapEnabled": true,
+      "taps": [
+        { "lowercase": "a", "uppercase": "A" },
+        { "lowercase": "ä", "uppercase": "Ä" }
+      ]
+    },
+    "KEYCODE_S": {
+      "lowercase": "s",
+      "uppercase": "S",
+      "multiTapEnabled": true,
+      "taps": [
+        { "lowercase": "s", "uppercase": "S" },
+        { "lowercase": "ß", "uppercase": "ẞ" }
+      ]
+    },
+    "KEYCODE_D": { "lowercase": "d", "uppercase": "D" },
+    "KEYCODE_F": { "lowercase": "f", "uppercase": "F" },
+    "KEYCODE_G": { "lowercase": "g", "uppercase": "G" },
+    "KEYCODE_H": { "lowercase": "h", "uppercase": "H" },
+    "KEYCODE_J": { "lowercase": "j", "uppercase": "J" },
+    "KEYCODE_K": { "lowercase": "k", "uppercase": "K" },
+    "KEYCODE_L": { "lowercase": "l", "uppercase": "L" },
+    "KEYCODE_Z": { "lowercase": "y", "uppercase": "Y" },
+    "KEYCODE_X": { "lowercase": "x", "uppercase": "X" },
+    "KEYCODE_C": { "lowercase": "c", "uppercase": "C" },
+    "KEYCODE_V": { "lowercase": "v", "uppercase": "V" },
+    "KEYCODE_B": { "lowercase": "b", "uppercase": "B" },
+    "KEYCODE_N": { "lowercase": "n", "uppercase": "N" },
+    "KEYCODE_M": { "lowercase": "m", "uppercase": "M" }
+  }
+}


### PR DESCRIPTION
## Summary

Add a separate German QWERTZ multi-tap keyboard layout asset (without changing the default `de_DE -> qwertz` mapping).

This provides an optional layout for users who want quick access to German special characters on hardware keyboards via repeated taps.

## What was added

New layout:
- `app/src/main/assets/common/layouts/german_multitap_qwertz.json`

Multi-tap character cycles:
- `a -> ä`
- `o -> ö`
- `u -> ü`
- `s -> ß` (uppercase maps to `ẞ`)

## Notes

- This is intentionally a **separate layout** and does **not** replace the existing `qwertz` layout.
- The default locale mapping for German remains unchanged (`de_DE -> qwertz`), so users can opt in to the multi-tap variant explicitly.

## Why

German users on physical keyboards may not always have direct access to umlauts and `ß`.  
A multi-tap variant offers a practical fallback while keeping the standard QWERTZ behavior available.