### PR TITLE
Add Alt+Shift layout switch, layout switch toast toggle

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/KeyboardLayoutSettingsScreen.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/KeyboardLayoutSettingsScreen.kt
@@ -64,6 +64,12 @@ fun KeyboardLayoutSettingsScreen(
     var physicalKeyboardProfileOverride by remember {
         mutableStateOf(SettingsManager.getPhysicalKeyboardProfileOverride(context))
     }
+    var altShiftLayoutSwitch by remember {
+        mutableStateOf(SettingsManager.isAltShiftLayoutSwitchEnabled(context))
+    }
+    var toastOnLayoutSwitch by remember {
+        mutableStateOf(SettingsManager.isToastOnLayoutSwitchEnabled(context))
+    }
     val detectedPhysicalProfile = remember { DeviceSpecific.physicalKeyboardName() }
     var showPhysicalProfileMenu by remember { mutableStateOf(false) }
     var selectedLayout by remember(locale, automaticLayoutMode) {
@@ -232,6 +238,8 @@ fun KeyboardLayoutSettingsScreen(
                         onClick = {
                             SettingsManager.setKeyboardLayoutAutoByLocale(context, automaticLayoutMode)
                             SettingsManager.setPhysicalKeyboardProfileOverride(context, physicalKeyboardProfileOverride)
+                            SettingsManager.setAltShiftLayoutSwitchEnabled(context, altShiftLayoutSwitch)
+                            SettingsManager.setToastOnLayoutSwitchEnabled(context, toastOnLayoutSwitch)
                             if (automaticLayoutMode) {
                                 onLayoutSelected(locale, selectedLayout)
                             } else {
@@ -386,6 +394,72 @@ fun KeyboardLayoutSettingsScreen(
                                 }
                             }
                         }
+                    }
+                }
+
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.alt_shift_layout_switch_title),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Text(
+                                text = stringResource(R.string.alt_shift_layout_switch_description),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Switch(
+                            checked = altShiftLayoutSwitch,
+                            onCheckedChange = { enabled ->
+                                altShiftLayoutSwitch = enabled
+                            }
+                        )
+                    }
+                }
+
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.toast_on_layout_switch_title),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Text(
+                                text = stringResource(R.string.toast_on_layout_switch_description),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Switch(
+                            checked = toastOnLayoutSwitch,
+                            onCheckedChange = { enabled ->
+                                toastOnLayoutSwitch = enabled
+                            }
+                        )
                     }
                 }
 

--- a/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
@@ -39,6 +39,7 @@ object SettingsManager {
     private const val KEY_KEYBOARD_LAYOUT = "keyboard_layout" // "qwerty", "azerty", etc.
     private const val KEY_KEYBOARD_LAYOUT_AUTO_BY_LOCALE = "keyboard_layout_auto_by_locale" // If true, resolve layout from subtype/locale mapping
     private const val KEY_KEYBOARD_LAYOUT_LIST = "keyboard_layout_list" // JSON array of layout ids for cycling
+    private const val KEY_ALT_SHIFT_LAYOUT_SWITCH = "alt_shift_layout_switch" // Enable Alt+Shift shortcut for layout cycling
     private const val KEY_PHYSICAL_KEYBOARD_PROFILE_OVERRIDE = "physical_keyboard_profile_override" // auto | key2 | Q25 | titan2 | titan2elite_qwerty | mp01
     private const val KEY_RESTORE_SYM_PAGE = "restore_sym_page" // SYM page to restore when returning from settings
     private const val KEY_PENDING_RESTORE_SYM_PAGE = "pending_restore_sym_page" // Temporary SYM page state saved when opening settings
@@ -112,6 +113,9 @@ object SettingsManager {
     private const val DEFAULT_LONG_PRESS_MODIFIER = "alt"
     private const val DEFAULT_KEYBOARD_LAYOUT = "qwerty"
     private const val DEFAULT_KEYBOARD_LAYOUT_AUTO_BY_LOCALE = true
+    private const val DEFAULT_ALT_SHIFT_LAYOUT_SWITCH = false
+    private const val KEY_TOAST_ON_LAYOUT_SWITCH = "toast_on_layout_switch"
+    private const val DEFAULT_TOAST_ON_LAYOUT_SWITCH = true
     private const val DEFAULT_PHYSICAL_KEYBOARD_PROFILE_OVERRIDE = "auto"
     private const val DEFAULT_SYM_AUTO_CLOSE = true
     private val DEFAULT_SYM_PAGES_CONFIG = SymPagesConfig()
@@ -1592,6 +1596,44 @@ object SettingsManager {
         val normalized = normalizePhysicalKeyboardProfileOverride(profile)
         getPreferences(context).edit()
             .putString(KEY_PHYSICAL_KEYBOARD_PROFILE_OVERRIDE, normalized)
+            .apply()
+    }
+
+    /**
+     * Returns whether Alt+Shift shortcut for keyboard layout cycling is enabled.
+     */
+    fun isAltShiftLayoutSwitchEnabled(context: Context): Boolean {
+        return getPreferences(context).getBoolean(
+            KEY_ALT_SHIFT_LAYOUT_SWITCH,
+            DEFAULT_ALT_SHIFT_LAYOUT_SWITCH
+        )
+    }
+
+    /**
+     * Enables/disables Alt+Shift shortcut for keyboard layout cycling.
+     */
+    fun setAltShiftLayoutSwitchEnabled(context: Context, enabled: Boolean) {
+        getPreferences(context).edit()
+            .putBoolean(KEY_ALT_SHIFT_LAYOUT_SWITCH, enabled)
+            .apply()
+    }
+
+    /**
+     * Returns whether toast notification on layout switch is enabled.
+     */
+    fun isToastOnLayoutSwitchEnabled(context: Context): Boolean {
+        return getPreferences(context).getBoolean(
+            KEY_TOAST_ON_LAYOUT_SWITCH,
+            DEFAULT_TOAST_ON_LAYOUT_SWITCH
+        )
+    }
+
+    /**
+     * Enables/disables toast notification on layout switch.
+     */
+    fun setToastOnLayoutSwitchEnabled(context: Context, enabled: Boolean) {
+        getPreferences(context).edit()
+            .putBoolean(KEY_TOAST_ON_LAYOUT_SWITCH, enabled)
             .apply()
     }
 

--- a/app/src/main/java/it/palsoftware/pastiera/backup/BackupContract.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/backup/BackupContract.kt
@@ -234,7 +234,9 @@ object PreferenceSchemas {
             "use_keyboard_proximity" to PreferenceValueType.BOOLEAN,
             "use_edit_type_ranking" to PreferenceValueType.BOOLEAN,
             "custom_input_styles" to PreferenceValueType.STRING,
-            "titan2_layout_enabled" to PreferenceValueType.BOOLEAN
+            "titan2_layout_enabled" to PreferenceValueType.BOOLEAN,
+            "alt_shift_layout_switch" to PreferenceValueType.BOOLEAN,
+            "toast_on_layout_switch" to PreferenceValueType.BOOLEAN
         ),
         dynamicKeys = listOf(
             PreferenceFileSchema.DynamicKey(

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
@@ -2372,6 +2372,32 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
             InputEventRouter.EditableFieldRoutingResult.Continue -> {}
         }
         
+        // Handle Alt+Shift for subtype cycling
+        if (
+            hasEditableField &&
+            event != null &&
+            event.repeatCount == 0 &&
+            SettingsManager.isAltShiftLayoutSwitchEnabled(this) &&
+            (((keyCode == KeyEvent.KEYCODE_SHIFT_LEFT || keyCode == KeyEvent.KEYCODE_SHIFT_RIGHT) &&
+                (event.isAltPressed || altPressed || altLatchActive || altOneShot)) ||
+                ((keyCode == KeyEvent.KEYCODE_ALT_LEFT || keyCode == KeyEvent.KEYCODE_ALT_RIGHT) &&
+                    (event.isShiftPressed || shiftPressed || shiftLayerLatched || shiftOneShot)))
+        ) {
+            modifierStateController.clearAltState(resetPressedState = true)
+            modifierStateController.clearShiftState(resetPressedState = true)
+
+            val showToast = SettingsManager.isToastOnLayoutSwitchEnabled(this)
+            SubtypeCycler.cycleToNextSubtype(
+                context = this,
+                imeServiceClass = PhysicalKeyboardInputMethodService::class.java,
+                assets = assets,
+                showToast = showToast
+            )
+
+            updateStatusBarText()
+            return true
+        }
+
         // Handle Ctrl+Space for subtype cycling
         if (
             hasEditableField &&
@@ -2404,7 +2430,8 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
             }
 
             // Cycle to next subtype
-            if (SubtypeCycler.cycleToNextSubtype(this, PhysicalKeyboardInputMethodService::class.java, assets, showToast = true)) {
+            val showToast = SettingsManager.isToastOnLayoutSwitchEnabled(this)
+            if (SubtypeCycler.cycleToNextSubtype(this, PhysicalKeyboardInputMethodService::class.java, assets, showToast = showToast)) {
                 shouldUpdateStatusBar = true
             }
 
@@ -2413,7 +2440,7 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
             }
             return true
         }
-        
+
         val ic = currentInputConnection
         val state = inputContextState
         val isAutoCorrectEnabled = SettingsManager.getAutoCorrectEnabled(this) && !state.shouldDisableAutoCorrect

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -242,6 +242,10 @@
     <string name="keyboard_layout_mode_title">Automatic Layout Mapping</string>
     <string name="keyboard_layout_mode_auto_description">ON: follow subtype/locale mapping defaults.</string>
     <string name="keyboard_layout_mode_manual_description">OFF: use one manually selected layout for all locales.</string>
+    <string name="alt_shift_layout_switch_title">Alt+Shift Layout Switch</string>
+    <string name="alt_shift_layout_switch_description">Cycle languages/layouts with Alt+Shift.</string>
+    <string name="toast_on_layout_switch_title">Layout Switch Toast</string>
+    <string name="toast_on_layout_switch_description">Show a toast when switching languages/layouts.</string>
     <string name="keyboard_profile_override_title">Physical Keyboard Profile</string>
     <string name="keyboard_profile_override_auto_description">Auto detect from device fingerprint (current: %1$s).</string>
     <string name="keyboard_profile_override_manual_description">Manual override for device-specific key mappings.</string>

--- a/app/src/test/java/it/palsoftware/pastiera/SettingsManagerLayoutSwitchTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/SettingsManagerLayoutSwitchTest.kt
@@ -1,0 +1,46 @@
+package it.palsoftware.pastiera
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SettingsManagerLayoutSwitchTest {
+
+    @Before
+    fun setUp() {
+        RuntimeEnvironment.getApplication()
+            .getSharedPreferences("pastiera_prefs", android.content.Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    @Test
+    fun altShiftLayoutSwitch_defaultsDisabled_andPersistsEnabledState() {
+        val context = RuntimeEnvironment.getApplication()
+
+        assertFalse(SettingsManager.isAltShiftLayoutSwitchEnabled(context))
+
+        SettingsManager.setAltShiftLayoutSwitchEnabled(context, true)
+
+        assertTrue(SettingsManager.isAltShiftLayoutSwitchEnabled(context))
+    }
+
+    @Test
+    fun layoutSwitchToast_defaultsEnabled_andPersistsDisabledState() {
+        val context = RuntimeEnvironment.getApplication()
+
+        assertTrue(SettingsManager.isToastOnLayoutSwitchEnabled(context))
+
+        SettingsManager.setToastOnLayoutSwitchEnabled(context, false)
+
+        assertFalse(SettingsManager.isToastOnLayoutSwitchEnabled(context))
+    }
+}

--- a/app/src/test/java/it/palsoftware/pastiera/backup/RestoreManagerAndBackupContractTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/backup/RestoreManagerAndBackupContractTest.kt
@@ -23,6 +23,18 @@ class RestoreManagerAndBackupContractTest {
     }
 
     @Test
+    fun layoutSwitchPreferences_areRecognizedForRestore() {
+        assertEquals(
+            PreferenceValueType.BOOLEAN,
+            PreferenceSchemas.expectedType("pastiera_prefs", "alt_shift_layout_switch")
+        )
+        assertEquals(
+            PreferenceValueType.BOOLEAN,
+            PreferenceSchemas.expectedType("pastiera_prefs", "toast_on_layout_switch")
+        )
+    }
+
+    @Test
     fun shouldNotifyUserDictionaryRefresh_whenUserDictionaryPrefsRestored() {
         val prefs = PreferencesRestoreSummary(
             appliedKeys = listOf("pastiera_prefs:user_dictionary_entries"),

--- a/app/src/test/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodServiceDeviceBehaviorTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodServiceDeviceBehaviorTest.kt
@@ -242,6 +242,40 @@ class PhysicalKeyboardInputMethodServiceDeviceBehaviorTest {
     }
 
     @Test
+    fun altShiftLayoutSwitch_consumesShortcutAndClearsModifiers_whenEnabled() {
+        val context = RuntimeEnvironment.getApplication()
+        SettingsManager.setAltShiftLayoutSwitchEnabled(context, true)
+        val t0 = 3_900L
+
+        service.onKeyDown(
+            KeyEvent.KEYCODE_ALT_LEFT,
+            keyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ALT_LEFT, t0, t0)
+        )
+        assertTrue(modifierController().altPressed)
+
+        val handled = service.onKeyDown(
+            KeyEvent.KEYCODE_SHIFT_LEFT,
+            keyEvent(
+                action = KeyEvent.ACTION_DOWN,
+                keyCode = KeyEvent.KEYCODE_SHIFT_LEFT,
+                downTime = t0,
+                eventTime = t0 + 80L,
+                metaState = KeyEvent.META_ALT_ON or KeyEvent.META_ALT_LEFT_ON
+            )
+        )
+
+        val modifier = modifierController()
+        assertTrue(handled)
+        assertFalse(modifier.altPressed)
+        assertFalse(modifier.altPhysicallyPressed)
+        assertFalse(modifier.altOneShot)
+        assertFalse(modifier.altLatchActive)
+        assertFalse(modifier.shiftPressed)
+        assertFalse(modifier.shiftOneShot)
+        assertFalse(modifier.capsLockEnabled)
+    }
+
+    @Test
     fun deviceSanity_symATogglesEmojiThenSymbols_exactMappings() {
         val t0 = 4_000L
 


### PR DESCRIPTION
Adds the option to use Alt+Shift keyboard shortcut (in addition to Ctrl-Space) for cycling through keyboard layouts, along with an option to disable toast notifications on layout switch (as they tend to cover input at the bottom of the screen, especially with status bar off). Alt+Shift is more ergonomic than Ctrl-Space for Titan 1/2/Slim, and used to be my preferred option with other keyboards allowing physical key layout switching. 

Tested and working on Unihertz Titan 2.

I added the options to the Customization page, please tell me if there is a better place for them.