### PR TITLE
Update TrackpadGestureDetector.kt

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
@@ -45,6 +45,7 @@ import it.palsoftware.pastiera.data.variation.VariationRepository
 import it.palsoftware.pastiera.inputmethod.SpeechRecognitionActivity
 import it.palsoftware.pastiera.inputmethod.subtype.AdditionalSubtypeUtils
 import it.palsoftware.pastiera.inputmethod.telex.VietnameseTelexProcessor
+import it.palsoftware.pastiera.inputmethod.trackpad.TrackpadEventDeviceResolver
 import it.palsoftware.pastiera.inputmethod.trackpad.TrackpadGestureDetector
 import java.util.Locale
 import android.view.inputmethod.InputMethodManager
@@ -1289,12 +1290,24 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
     private fun buildTrackpadGestureDetector(): TrackpadGestureDetector {
         val gesturesEnabled = SettingsManager.getTrackpadGesturesEnabled(this)
         val swipeThreshold = SettingsManager.getTrackpadSwipeThreshold(this).toInt()
-        Log.d(TRACKPAD_DEBUG_TAG, "buildTrackpadGestureDetector() - gesturesEnabled=$gesturesEnabled, swipeThreshold=$swipeThreshold")
+        val eventDevice = resolveTrackpadEventDevice()
+        Log.d(
+            TRACKPAD_DEBUG_TAG,
+            "buildTrackpadGestureDetector() - gesturesEnabled=$gesturesEnabled, swipeThreshold=$swipeThreshold, eventDevice=$eventDevice"
+        )
         return TrackpadGestureDetector(
             isEnabled = { SettingsManager.getTrackpadGesturesEnabled(this) },
             onSwipeUp = { third -> acceptSuggestionAtIndex(third) },
             scope = trackpadScope,
-            swipeUpThreshold = swipeThreshold
+            swipeUpThreshold = swipeThreshold,
+            eventDevice = eventDevice
+        )
+    }
+
+    private fun resolveTrackpadEventDevice(): String {
+        return TrackpadEventDeviceResolver.resolve(
+            physicalKeyboardName = DeviceSpecific.physicalKeyboardName(),
+            firmwareIncremental = Build.VERSION.INCREMENTAL.orEmpty()
         )
     }
     

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/trackpad/TrackpadEventDeviceResolver.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/trackpad/TrackpadEventDeviceResolver.kt
@@ -1,0 +1,37 @@
+package it.palsoftware.pastiera.inputmethod.trackpad
+
+object TrackpadEventDeviceResolver {
+    const val LEGACY_EVENT_DEVICE = "/dev/input/event7"
+    const val UPDATED_TITAN2_EVENT_DEVICE = "/dev/input/event6"
+    const val UPDATED_TITAN2_MIN_FIRMWARE = "V01.00.12"
+
+    fun resolve(
+        physicalKeyboardName: String,
+        firmwareIncremental: String
+    ): String {
+        if (!physicalKeyboardName.equals("titan2", ignoreCase = true)) {
+            return LEGACY_EVENT_DEVICE
+        }
+        return if (isFirmwareAtLeast(firmwareIncremental, UPDATED_TITAN2_MIN_FIRMWARE)) {
+            UPDATED_TITAN2_EVENT_DEVICE
+        } else {
+            LEGACY_EVENT_DEVICE
+        }
+    }
+
+    internal fun isFirmwareAtLeast(current: String, minimum: String): Boolean {
+        val currentParts = parseFirmwareVersionParts(current) ?: return false
+        val minimumParts = parseFirmwareVersionParts(minimum) ?: return false
+        for (index in 0..2) {
+            if (currentParts[index] > minimumParts[index]) return true
+            if (currentParts[index] < minimumParts[index]) return false
+        }
+        return true
+    }
+
+    private fun parseFirmwareVersionParts(version: String): List<Int>? {
+        val match = Regex("V(\\d+)\\.(\\d+)\\.(\\d+)", RegexOption.IGNORE_CASE).find(version)
+            ?: return null
+        return match.groupValues.drop(1).map { it.toInt() }
+    }
+}

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/trackpad/TrackpadGestureDetector.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/trackpad/TrackpadGestureDetector.kt
@@ -205,11 +205,10 @@ class TrackpadGestureDetector(
         const val DEFAULT_TRACKPAD_MAX_X = 1440
         const val DEFAULT_SWIPE_UP_THRESHOLD = 300
         const val DEFAULT_MIN_VELOCITY_THRESHOLD = 2.0  // pixels per millisecond (e.g., 1.0 px/ms = 1000 px/s)
-        const val DEFAULT_EVENT_DEVICE = "/dev/input/event7"
+        const val DEFAULT_EVENT_DEVICE = TrackpadEventDeviceResolver.LEGACY_EVENT_DEVICE
         const val DEFAULT_LOG_TAG = "PastieraIME"
         private const val DEBUG_TAG = "TrackpadDebug"
     }
 }
-
 
 

--- a/app/src/test/java/it/palsoftware/pastiera/inputmethod/trackpad/TrackpadEventDeviceResolverTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/inputmethod/trackpad/TrackpadEventDeviceResolverTest.kt
@@ -1,0 +1,67 @@
+package it.palsoftware.pastiera.inputmethod.trackpad
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TrackpadEventDeviceResolverTest {
+    @Test
+    fun `non Titan 2 uses legacy event device regardless of firmware`() {
+        assertEquals(
+            TrackpadEventDeviceResolver.LEGACY_EVENT_DEVICE,
+            TrackpadEventDeviceResolver.resolve(
+                physicalKeyboardName = "titan",
+                firmwareIncremental = "V99.99.99"
+            )
+        )
+    }
+
+    @Test
+    fun `Titan 2 firmware before V01_00_12 uses legacy event device`() {
+        assertEquals(
+            TrackpadEventDeviceResolver.LEGACY_EVENT_DEVICE,
+            TrackpadEventDeviceResolver.resolve(
+                physicalKeyboardName = "titan2",
+                firmwareIncremental = "V01.00.11"
+            )
+        )
+    }
+
+    @Test
+    fun `Titan 2 firmware V01_00_12 and newer uses updated event device`() {
+        listOf(
+            "V01.00.12",
+            "Titan 2_EEA_V01.00.12-20260413",
+            "V01.00.14"
+        ).forEach { firmware ->
+            assertEquals(
+                firmware,
+                TrackpadEventDeviceResolver.UPDATED_TITAN2_EVENT_DEVICE,
+                TrackpadEventDeviceResolver.resolve(
+                    physicalKeyboardName = "titan2",
+                    firmwareIncremental = firmware
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `firmware parsing compares semantic version parts`() {
+        assertFalse(TrackpadEventDeviceResolver.isFirmwareAtLeast("V01.00.11", "V01.00.12"))
+        assertTrue(TrackpadEventDeviceResolver.isFirmwareAtLeast("V01.00.12", "V01.00.12"))
+        assertTrue(TrackpadEventDeviceResolver.isFirmwareAtLeast("V01.00.14", "V01.00.12"))
+        assertTrue(TrackpadEventDeviceResolver.isFirmwareAtLeast("V01.01.00", "V01.00.12"))
+    }
+
+    @Test
+    fun `unparseable Titan 2 firmware falls back to legacy event device`() {
+        assertEquals(
+            TrackpadEventDeviceResolver.LEGACY_EVENT_DEVICE,
+            TrackpadEventDeviceResolver.resolve(
+                physicalKeyboardName = "titan2",
+                firmwareIncremental = "unknown"
+            )
+        )
+    }
+}


### PR DESCRIPTION
In the latest FW 20260422 they changed the device mappings, and now `device6` is the trackpad. This change will make sure the feature works for people using the updated FW - but it will break on older ones.

I'm also working on a better autodetect feature on my own project that uses the trackpad features but it's not finished yet.

Fixes https://github.com/palsoftware/pastiera/issues/187