### PR TITLE
Q25 Lockscreen pin support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
     <!-- Permesso per mostrare finestre overlay (per debug trackpad) -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
+    <!-- Permission to receive boot notifications (Direct Boot support) -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <!-- Query per vedere tutte le app installate che possono essere avviate -->
     <queries>
         <intent>
@@ -105,6 +108,7 @@
             android:name=".inputmethod.PhysicalKeyboardInputMethodService"
             android:label="${imeLabel}"
             android:permission="android.permission.BIND_INPUT_METHOD"
+            android:directBootAware="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.view.InputMethod" />
@@ -114,6 +118,17 @@
                 android:resource="@xml/method" />
         </service>
 
+        <!-- BroadcastReceiver for Direct Boot support -->
+        <receiver
+            android:name=".inputmethod.DirectBootReceiver"
+            android:directBootAware="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+        
         <!-- Attività helper per il riconoscimento vocale -->
         <activity
             android:name=".inputmethod.SpeechRecognitionActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,6 +161,20 @@
             android:enabled="true"
             android:exported="true"
             android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
+
+        <!-- Accessibility service for entering the PIN on the lockscreen -->
+        <service
+            android:name=".accessibility.LockscreenPinEntry"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="true"
+	        android:label="@string/accessibility_service_description">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/it/palsoftware/pastiera/AccessibilitySettingsScreen.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/AccessibilitySettingsScreen.kt
@@ -1,7 +1,10 @@
 package it.palsoftware.pastiera
 
+import android.content.Intent
+import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -39,6 +42,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import it.palsoftware.pastiera.accessibility.LockscreenPinEntry
+import it.palsoftware.pastiera.inputmethod.DeviceSpecific
 
 @Composable
 fun AccessibilitySettingsScreen(
@@ -54,6 +59,9 @@ fun AccessibilitySettingsScreen(
     }
     var suggestionsAnnouncementDelayMs by remember {
         mutableStateOf(SettingsManager.getAccessibilitySuggestionsAnnouncementDelayMs(context))
+    }
+    var pinInputOnLockscreenEnabled by remember {
+        mutableStateOf(SettingsManager.getLockscreenPinEntry(context))
     }
 
     BackHandler { onBack() }
@@ -94,6 +102,51 @@ fun AccessibilitySettingsScreen(
                 .padding(paddingValues)
                 .verticalScroll(rememberScrollState())
         ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(96.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.settings_accessibility_lockscreen_pin_entry),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1
+                        )
+                        Text(
+                            text = stringResource(R.string.settings_accessibility_lockscreen_pin_entry_description),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = pinInputOnLockscreenEnabled,
+                        enabled = DeviceSpecific.isPhysicalKeyboardDevice(),
+                        onCheckedChange = { enabled ->
+                            if (enabled) {
+                                if (LockscreenPinEntry.connected.value) {
+                                    pinInputOnLockscreenEnabled = enabled
+                                    SettingsManager.setLockscreenPinEntry(context, enabled)
+                                } else {
+                                    // Open accessibility settings to enable the service
+                                    val intent =
+                                        Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS)
+                                    context.startActivity(intent)
+                                }
+                            }
+                        }
+                    )
+                }
+            }
+
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.provider.OpenableColumns
 import android.util.Log
 import android.view.KeyEvent
+import it.palsoftware.pastiera.accessibility.LockscreenPinEntry
 import it.palsoftware.pastiera.inputmethod.DeviceSpecific
 import org.json.JSONArray
 import org.json.JSONObject
@@ -89,6 +90,9 @@ object SettingsManager {
     private const val KEY_APP_ENTER_BEHAVIOR_PRESET = "app_enter_behavior_preset"
     private const val KEY_APP_ENTER_BEHAVIOR_OVERRIDES = "app_enter_behavior_overrides"
     
+    private const val KEY_LOCKSCREEN_PIN_ENTRY = "lockscreen_pin_entry"
+    private const val DEFAULT_LOCKSCREEN_PIN_ENTRY = true
+
     // Status bar button slot configuration keys
     private const val KEY_STATUS_BAR_SLOT_LEFT = "status_bar_slot_left"
     private const val KEY_STATUS_BAR_SLOT_RIGHT_1 = "status_bar_slot_right_1"
@@ -2261,6 +2265,27 @@ object SettingsManager {
             .apply()
     }
 
+    /**
+     * Returns whether PIN entry on lockscreen is enabled
+     */
+    fun getLockscreenPinEntry(context: Context): Boolean {
+        // only return the actual value if the accessibility service is enabled
+        if (LockscreenPinEntry.connected.value)
+            return getPreferences(context).getBoolean(KEY_LOCKSCREEN_PIN_ENTRY, DEFAULT_LOCKSCREEN_PIN_ENTRY)
+        return false
+    }
+
+    /**
+     * Enable/disablin PIN entry on lockscreen
+     */
+    fun setLockscreenPinEntry(context: Context, enabled: Boolean) {
+        // only attempt to set the value if the accessibility service is enabled
+        if (enabled && ! LockscreenPinEntry.connected.value)
+            return
+        getPreferences(context).edit()
+            .putBoolean(KEY_LOCKSCREEN_PIN_ENTRY, enabled)
+            .apply()
+    }
     /**
      * Returns whether Alt+Shift shortcut for keyboard layout cycling is enabled.
      */

--- a/app/src/main/java/it/palsoftware/pastiera/accessibility/LockscreenPinEntryAccessibilityService.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/accessibility/LockscreenPinEntryAccessibilityService.kt
@@ -1,0 +1,241 @@
+package it.palsoftware.pastiera.accessibility
+
+import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.app.KeyguardManager
+import android.util.Log
+import android.view.KeyEvent
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import it.palsoftware.pastiera.SettingsManager
+import it.palsoftware.pastiera.inputmethod.DeviceSpecific
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Accessibility service that automatically focuses input fields when apps are opened.
+ * Supports browser address bars, message input fields, and other text fields.
+ */
+class LockscreenPinEntry : AccessibilityService() {
+    
+    companion object {
+        private const val TAG = "LockscreenPinEntry"
+        val connected = MutableStateFlow(false)
+    }
+        
+    override fun onServiceConnected() {
+        super.onServiceConnected()
+        
+        val info = AccessibilityServiceInfo()
+        info.eventTypes = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED or 
+                         AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
+        info.feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
+        info.flags = AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS or
+                AccessibilityServiceInfo.FLAG_REQUEST_FILTER_KEY_EVENTS
+        info.notificationTimeout = 100
+        
+        serviceInfo = info
+
+        connected.tryEmit(true)
+
+        Log.d(TAG, "LockscreenPinEntry Accessibility Service connected")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        connected.tryEmit(true)
+        Log.d(TAG, "LockscreenPinEntry Accessibility Service destroyed")
+    }
+
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+        if (event == null) return
+
+        // Check if accessibility service has proper permissions
+        if (!isAccessibilityServiceEnabled()) {
+            Log.w(TAG, "Accessibility service not properly enabled")
+            return
+        }
+    }
+
+    override fun onInterrupt() {
+        Log.d(TAG, "LockscreenPinEntry Accessibility Service interrupted")
+    }
+
+    /**
+     * Check if the accessibility service is properly enabled with required permissions.
+     */
+    private fun isAccessibilityServiceEnabled(): Boolean {
+        try {
+            val info = serviceInfo
+            if (info == null) {
+                Log.w(TAG, "Service info is null")
+                return false
+            }
+            
+            // Check if we have the required event types
+            val hasWindowStateChanged = (info.eventTypes and AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) != 0
+            if (!hasWindowStateChanged) {
+                Log.w(TAG, "Missing TYPE_WINDOW_STATE_CHANGED event type")
+                return false
+            }
+            
+            // Check if we have the flag to retrieve interactive windows
+            val canRetrieveWindows = (info.flags and AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS) != 0
+            if (!canRetrieveWindows) {
+                Log.w(TAG, "Missing FLAG_RETRIEVE_INTERACTIVE_WINDOWS flag")
+                return false
+            }
+            
+            return true
+        } catch (e: Exception) {
+            Log.e(TAG, "Error checking accessibility service status", e)
+            return false
+        }
+    }
+
+    // --- Lockscreen PIN Entry ---
+
+    private fun isDeviceLocked(): Boolean {
+        val keyguardManager = getSystemService(KEYGUARD_SERVICE) as? KeyguardManager
+        return keyguardManager?.isKeyguardLocked == true
+    }
+
+    private fun clickPinButton(digit: String): Boolean {
+        val rootNode = rootInActiveWindow ?: return false
+        try {
+            // Try common SystemUI view IDs for PIN pad buttons
+            val pinViewIds = listOf(
+                "com.android.systemui:id/key$digit",
+                "com.android.systemui:id/pin_key_$digit",
+                "com.android.systemui:id/digit_$digit"
+            )
+            for (viewId in pinViewIds) {
+                val nodes = rootNode.findAccessibilityNodeInfosByViewId(viewId)
+                if (nodes.isNotEmpty()) {
+                    for (node in nodes) {
+                        if (node.isClickable) {
+                            node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+                            node.recycle()
+                            return true
+                        }
+                        node.recycle()
+                    }
+                }
+            }
+
+            // Fallback: find button by text content
+            val nodes = rootNode.findAccessibilityNodeInfosByText(digit)
+            for (node in nodes) {
+                if (node.isClickable && node.className?.toString()?.contains("Button") != false) {
+                    val nodeText = node.text?.toString()?.trim()
+                    if (nodeText == digit) {
+                        node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+                        node.recycle()
+                        return true
+                    }
+                }
+                node.recycle()
+            }
+            return false
+        } finally {
+            rootNode.recycle()
+        }
+    }
+
+    private fun clickPinEnter(): Boolean {
+        val rootNode = rootInActiveWindow ?: return false
+        try {
+            val enterIds = listOf(
+                "com.android.systemui:id/key_enter",
+                "com.android.systemui:id/pin_key_enter",
+                "com.android.systemui:id/check_button"
+            )
+            for (viewId in enterIds) {
+                val nodes = rootNode.findAccessibilityNodeInfosByViewId(viewId)
+                if (nodes.isNotEmpty()) {
+                    for (node in nodes) {
+                        if (node.isClickable) {
+                            node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+                            node.recycle()
+                            return true
+                        }
+                        node.recycle()
+                    }
+                }
+            }
+
+            return findAndClickNode(rootNode) { node ->
+                val desc = node.contentDescription?.toString()?.lowercase() ?: ""
+                node.isClickable && (desc.contains("enter") || desc.contains("confirm") || desc.contains("ok"))
+            }
+        } finally {
+            rootNode.recycle()
+        }
+    }
+
+    private fun clickPinDelete(): Boolean {
+        val rootNode = rootInActiveWindow ?: return false
+        try {
+            val deleteIds = listOf(
+                "com.android.systemui:id/delete_button",
+                "com.android.systemui:id/key_backspace",
+                "com.android.systemui:id/pin_key_delete"
+            )
+            for (viewId in deleteIds) {
+                val nodes = rootNode.findAccessibilityNodeInfosByViewId(viewId)
+                if (nodes.isNotEmpty()) {
+                    for (node in nodes) {
+                        if (node.isClickable) {
+                            node.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+                            node.recycle()
+                            return true
+                        }
+                        node.recycle()
+                    }
+                }
+            }
+
+            return findAndClickNode(rootNode) { node ->
+                val desc = node.contentDescription?.toString()?.lowercase() ?: ""
+                node.isClickable && (desc.contains("delete") || desc.contains("backspace"))
+            }
+        } finally {
+            rootNode.recycle()
+        }
+    }
+
+    private fun findAndClickNode(root: AccessibilityNodeInfo, predicate: (AccessibilityNodeInfo) -> Boolean): Boolean {
+        if (predicate(root)) {
+            root.performAction(AccessibilityNodeInfo.ACTION_CLICK)
+            return true
+        }
+        for (i in 0 until root.childCount) {
+            val child = root.getChild(i) ?: continue
+            if (findAndClickNode(child, predicate)) {
+                child.recycle()
+                return true
+            }
+            child.recycle()
+        }
+        return false
+    }
+
+    override fun onKeyEvent(event: KeyEvent?): Boolean {
+        if (event == null || event.action != KeyEvent.ACTION_DOWN) return false
+        if (!SettingsManager.getLockscreenPinEntry(this)) return false
+        if (!isDeviceLocked()) return false
+
+        val keyCode = event.keyCode
+
+        if (keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_DPAD_CENTER) {
+            return clickPinEnter()
+        }
+
+        if (keyCode == KeyEvent.KEYCODE_DEL) {
+            return clickPinDelete()
+        }
+
+        val digit = DeviceSpecific.getDigitFromKeyCode(keyCode) ?: return false
+        return clickPinButton(digit)
+    }
+}

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/DeviceSpecific.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/DeviceSpecific.kt
@@ -409,6 +409,49 @@ object DeviceSpecific {
         }
     }
 
+    // convert keycode to digit
+    // used by the lockscreen PIN input accessibility service
+    fun getDigitFromKeyCode(keyCode: Int): String? {
+        // Blackberry keyboards, as well as the the Minimal phone, have a dedicated 0 key
+        // and [123456789] are mapped to [WERSDFZXC]
+        if (currentDeviceProfile().family == KeyboardFamily.BLACKBERRY ||
+            currentDeviceProfile().family == KeyboardFamily.MINIMAL )
+        {
+            return when (keyCode) {
+                KeyEvent.KEYCODE_W, KeyEvent.KEYCODE_1 -> "1"
+                KeyEvent.KEYCODE_E, KeyEvent.KEYCODE_2 -> "2"
+                KeyEvent.KEYCODE_R, KeyEvent.KEYCODE_3 -> "3"
+                KeyEvent.KEYCODE_S, KeyEvent.KEYCODE_4 -> "4"
+                KeyEvent.KEYCODE_D, KeyEvent.KEYCODE_5 -> "5"
+                KeyEvent.KEYCODE_F, KeyEvent.KEYCODE_6 -> "6"
+                KeyEvent.KEYCODE_Z, KeyEvent.KEYCODE_7 -> "7"
+                KeyEvent.KEYCODE_X, KeyEvent.KEYCODE_8 -> "8"
+                KeyEvent.KEYCODE_C, KeyEvent.KEYCODE_9 -> "9"
+                                    KeyEvent.KEYCODE_0 -> "0"
+                else -> null
+            }
+        }
+        // Unihertz keyboards have a different mapping;
+        // [1234567890] are mapped to [WERSDFXCVQ]
+        if (currentDeviceProfile().family == KeyboardFamily.UNIHERTZ)
+        {
+            return when (keyCode) {
+                KeyEvent.KEYCODE_W, KeyEvent.KEYCODE_1 -> "1"
+                KeyEvent.KEYCODE_E, KeyEvent.KEYCODE_2 -> "2"
+                KeyEvent.KEYCODE_R, KeyEvent.KEYCODE_3 -> "3"
+                KeyEvent.KEYCODE_S, KeyEvent.KEYCODE_4 -> "4"
+                KeyEvent.KEYCODE_D, KeyEvent.KEYCODE_5 -> "5"
+                KeyEvent.KEYCODE_F, KeyEvent.KEYCODE_6 -> "6"
+                KeyEvent.KEYCODE_X, KeyEvent.KEYCODE_7 -> "7"
+                KeyEvent.KEYCODE_C, KeyEvent.KEYCODE_8 -> "8"
+                KeyEvent.KEYCODE_V, KeyEvent.KEYCODE_9 -> "9"
+                KeyEvent.KEYCODE_Q, KeyEvent.KEYCODE_0 -> "0"
+                else -> null
+            }
+        }
+        // otherwise, mapping doesn't apply
+        return null
+    }
     fun physicalKeyboardName(): String {
         return currentDeviceProfile().physicalLayoutName
     }

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/DirectBootReceiver.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/DirectBootReceiver.kt
@@ -1,0 +1,98 @@
+package it.palsoftware.pastiera.inputmethod
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+/**
+ * BroadcastReceiver to handle Direct Boot events.
+ * 
+ * Direct Boot allows the keyboard to function before the device is unlocked,
+ * which is essential for entering PIN/password or using the keyboard in the lock screen.
+ * 
+ * This receiver listens for:
+ * - LOCKED_BOOT_COMPLETED: Device has booted, but user hasn't unlocked it yet
+ * - BOOT_COMPLETED: Device has booted and user has unlocked it
+ */
+class DirectBootReceiver : BroadcastReceiver() {
+    
+    companion object {
+        private const val TAG = "DirectBootReceiver"
+    }
+    
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            Intent.ACTION_LOCKED_BOOT_COMPLETED -> {
+                Log.i(TAG, "Device booted in Direct Boot mode (locked)")
+                // Initialize device-protected storage
+                initializeDeviceProtectedStorage(context)
+            }
+            Intent.ACTION_BOOT_COMPLETED -> {
+                Log.i(TAG, "Device fully booted and unlocked")
+                // Migrate settings from credential-protected to device-protected storage
+                migrateToDeviceProtectedStorage(context)
+            }
+        }
+    }
+    
+    /**
+     * Initialize services using device-protected storage.
+     * This storage is available before the device is unlocked.
+     */
+    private fun initializeDeviceProtectedStorage(context: Context) {
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                val deviceContext = context.createDeviceProtectedStorageContext()
+                // Access preferences to ensure they're created
+                val prefs = deviceContext.getSharedPreferences("pastiera_prefs", Context.MODE_PRIVATE)
+                Log.i(TAG, "Device-protected storage initialized with ${prefs.all.size} settings")
+                
+                // Note: Android may still use system keyboard during locked boot for security.
+                // This is a system limitation - third-party IMEs may be restricted during
+                // credential entry to prevent potential keylogging or security exploits.
+                Log.i(TAG, "IME service is directBootAware and ready, but Android may use system keyboard for security")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error initializing device-protected storage", e)
+        }
+    }
+    
+    /**
+     * Migrate settings from credential-protected to device-protected storage.
+     * This ensures settings persist across reboots even before unlock.
+     */
+    private fun migrateToDeviceProtectedStorage(context: Context) {
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                val credentialContext = context
+                val deviceContext = context.createDeviceProtectedStorageContext()
+                
+                val credentialPrefs = credentialContext.getSharedPreferences("pastiera_prefs", Context.MODE_PRIVATE)
+                val devicePrefs = deviceContext.getSharedPreferences("pastiera_prefs", Context.MODE_PRIVATE)
+                
+                // If device-protected storage is empty but credential storage has data, migrate
+                if (devicePrefs.all.isEmpty() && credentialPrefs.all.isNotEmpty()) {
+                    Log.i(TAG, "Migrating ${credentialPrefs.all.size} settings to device-protected storage")
+                    
+                    val editor = devicePrefs.edit()
+                    credentialPrefs.all.forEach { (key, value) ->
+                        when (value) {
+                            is Boolean -> editor.putBoolean(key, value)
+                            is Int -> editor.putInt(key, value)
+                            is Long -> editor.putLong(key, value)
+                            is Float -> editor.putFloat(key, value)
+                            is String -> editor.putString(key, value)
+                            is Set<*> -> @Suppress("UNCHECKED_CAST")
+                                editor.putStringSet(key, value as Set<String>)
+                        }
+                    }
+                    editor.apply()
+                    Log.i(TAG, "Settings migration completed")
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error during storage migration", e)
+        }
+    }
+}

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
@@ -1067,7 +1067,19 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
 
     override fun onCreate() {
         super.onCreate()
-        prefs = getSharedPreferences("pastiera_prefs", Context.MODE_PRIVATE)
+        // Use device-protected storage for Direct Boot support (Android N+)
+        // This allows the IME to remain active even before device unlock
+        prefs = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            try {
+                val deviceContext = createDeviceProtectedStorageContext()
+                deviceContext.getSharedPreferences("pastiera_prefs", Context.MODE_PRIVATE)
+            } catch (e: Exception) {
+                Log.e("PhysicalKeyboardIME", "Failed to create device protected storage, using default", e)
+                getSharedPreferences("pastiera_prefs", Context.MODE_PRIVATE)
+            }
+        } else {
+            getSharedPreferences("pastiera_prefs", Context.MODE_PRIVATE)
+        }
         clearAltOnSpaceEnabled = SettingsManager.getClearAltOnSpace(this)
         physicalKeyboardProfileOverride = SettingsManager.getPhysicalKeyboardProfileOverride(this)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -966,4 +966,8 @@ Each key can be configured as Keycode, Action, Native Ctrl, or None. Use overrid
     <string name="sym_key_content_description">%1$s, %2$s</string>
     <string name="status_bar_button_minimal_ui_description">Toggle compact keyboard UI</string>
     <string name="status_bar_buttons_reset">Reset</string>
+    <!-- Lockscreen PIN -->
+    <string name="accessibility_service_description">Enable PIN typing on the lock screen</string>
+    <string name="settings_accessibility_lockscreen_pin_entry">Enable PIN typing on the lock screen</string>
+    <string name="settings_accessibility_lockscreen_pin_entry_description">Requires the Accessibility service to be enabled</string>
 </resources>

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagRetrieveInteractiveWindows|flagRequestFilterKeyEvents"
+    android:canRetrieveWindowContent="true"
+    android:canRequestFilterKeyEvents="true"
+    android:description="@string/accessibility_service_description"
+    android:notificationTimeout="100"
+    android:settingsActivity="it.palsoftware.pastiera.MainActivity" />


### PR DESCRIPTION
This PR enables PIN input using the keyboard on the lock screen (at least on the Q25, the system does not provide that functionality).
DirectBoot support is implemented; while this does not result in the ability to unlock the device after boot by typing a PIN using the keyboard, it is likely that it will do so for ROMs into which this will be included.
DirectBoot support was adapted from [Sri](https://github.com/sriharshaKanukuntla)'s [TypeQ25](https://github.com/sriharshaKanukuntla/TypeQ25) - itself a Pastiera derivative work.