### PR TITLE
Add original Titan keyboard profile

### DIFF
--- a/app/src/main/assets/common/about_credits.md
+++ b/app/src/main/assets/common/about_credits.md
@@ -8,7 +8,7 @@ Andrea Palumbo (PalSoftware)
 Andrea Palumbo, Patrick Zauner
 
 #### Additional Contributors
-Justin Mitchell, NeoTheFox, Oleksii Ilienko, Nikola Vukobrat, Mircea Horea IONICĂ, Nikita Tseykovets, Ivan Bulanov, Ratmir Karabut, Troidem, Vasu Bhatia, Zsolt Sz. Sz. Raven, Burekmaster (SVG logo assets)
+Justin Mitchell, NeoTheFox, Oleksii Ilienko, Nikola Vukobrat, Mircea Horea IONICĂ, Nikita Tseykovets, Ivan Bulanov, Ratmir Karabut, Troidem, Vasu Bhatia, Zsolt Sz. Sz. Raven, Burekmaster (SVG logo assets), glebkuchay
 ---
 #### Pastiera Beta Testing Team
 Laggy Luke, Vittorio, Emmanuel, Sadako, NotTeganQuinn, DrumSyBeat, [Shane Craig (ShaneCraig.Tech)](https://shanecraig.tech/)

--- a/app/src/main/assets/devices/titan/alt_key_mappings.json
+++ b/app/src/main/assets/devices/titan/alt_key_mappings.json
@@ -1,0 +1,30 @@
+{
+  "mappings": {
+    "KEYCODE_Q": ":",
+    "KEYCODE_W": "/",
+    "KEYCODE_E": "_",
+    "KEYCODE_R": "-",
+    "KEYCODE_T": "(",
+    "KEYCODE_Y": ")",
+    "KEYCODE_U": "1",
+    "KEYCODE_I": "2",
+    "KEYCODE_O": "3",
+    "KEYCODE_P": "0",
+    "KEYCODE_A": "@",
+    "KEYCODE_S": "'",
+    "KEYCODE_D": "\"",
+    "KEYCODE_F": "+",
+    "KEYCODE_G": "*",
+    "KEYCODE_H": "#",
+    "KEYCODE_J": "4",
+    "KEYCODE_K": "5",
+    "KEYCODE_L": "6",
+    "KEYCODE_Z": "!",
+    "KEYCODE_X": "?",
+    "KEYCODE_C": ",",
+    "KEYCODE_V": ".",
+    "KEYCODE_B": "7",
+    "KEYCODE_N": "8",
+    "KEYCODE_M": "9"
+  }
+}

--- a/app/src/main/java/it/palsoftware/pastiera/KeyboardLayoutSettingsScreen.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/KeyboardLayoutSettingsScreen.kt
@@ -384,7 +384,7 @@ fun KeyboardLayoutSettingsScreen(
                                 expanded = showPhysicalProfileMenu,
                                 onDismissRequest = { showPhysicalProfileMenu = false }
                             ) {
-                                listOf("auto", "key2", "Q25", "titan2", "titan2elite_qwerty", "mp01").forEach { profile ->
+                                listOf("auto", "key2", "Q25", "titan", "titan2", "titan2elite_qwerty", "mp01").forEach { profile ->
                                     DropdownMenuItem(
                                         text = { Text(keyboardProfileLabel(context, profile)) },
                                         onClick = {
@@ -706,6 +706,7 @@ private fun keyboardProfileLabel(context: Context, profile: String): String {
     return when (profile) {
         "key2" -> context.getString(R.string.keyboard_profile_option_key2)
         "Q25" -> context.getString(R.string.keyboard_profile_option_q25)
+        "titan" -> context.getString(R.string.keyboard_profile_option_titan)
         "titan2" -> context.getString(R.string.keyboard_profile_option_titan2)
         "titan2elite_qwerty" -> context.getString(R.string.keyboard_profile_option_titan2elite_qwerty)
         "mp01" -> context.getString(R.string.keyboard_profile_option_mp01)

--- a/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
@@ -62,7 +62,7 @@ object SettingsManager {
     const val KEY_KEYBOARD_LAYOUT_AUTO_MAPPING_UPDATED = "keyboard_layout_auto_mapping_updated"
     private const val KEY_KEYBOARD_LAYOUT_LIST = "keyboard_layout_list" // JSON array of layout ids for cycling
     private const val KEY_ALT_SHIFT_LAYOUT_SWITCH = "alt_shift_layout_switch" // Enable Alt+Shift shortcut for layout cycling
-    private const val KEY_PHYSICAL_KEYBOARD_PROFILE_OVERRIDE = "physical_keyboard_profile_override" // auto | key2 | Q25 | titan2 | titan2elite_qwerty | mp01
+    private const val KEY_PHYSICAL_KEYBOARD_PROFILE_OVERRIDE = "physical_keyboard_profile_override" // auto | key2 | Q25 | titan | titan2 | titan2elite_qwerty | mp01
     private const val KEY_PHYSICAL_KEYBOARD_CURRENCY_SYMBOL = "physical_keyboard_currency_symbol" // Currency symbol for dedicated hardware keys
     private const val KEY_RESTORE_SYM_PAGE = "restore_sym_page" // SYM page to restore when returning from settings
     private const val KEY_PENDING_RESTORE_SYM_PAGE = "pending_restore_sym_page" // Temporary SYM page state saved when opening settings
@@ -2657,7 +2657,7 @@ object SettingsManager {
 
     /**
      * Returns the manual physical keyboard profile override used for device-specific mappings.
-     * Supported values: auto, key2, Q25, titan2, titan2elite_qwerty, mp01.
+     * Supported values: auto, key2, Q25, titan, titan2, titan2elite_qwerty, mp01.
      */
     fun getPhysicalKeyboardProfileOverride(context: Context): String {
         val value = getPreferences(context).getString(
@@ -2742,6 +2742,7 @@ object SettingsManager {
             normalized.equals("auto", ignoreCase = true) -> "auto"
             normalized.equals("key2", ignoreCase = true) -> "key2"
             normalized.equals("q25", ignoreCase = true) -> "Q25"
+            normalized.equals("titan", ignoreCase = true) -> "titan"
             normalized.equals("titan2", ignoreCase = true) -> "titan2"
             normalized.equals("titan2elite_qwerty", ignoreCase = true) -> "titan2elite_qwerty"
             normalized.equals("mp01", ignoreCase = true) -> "mp01"

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/DeviceSpecific.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/DeviceSpecific.kt
@@ -262,10 +262,14 @@ object DeviceSpecific {
             )
         }
         if (isTitanFamily(fp)) {
+            val model = resolveTitanModel(fp)
             return DeviceProfile(
                 family = KeyboardFamily.UNIHERTZ,
-                model = resolveTitanModel(fp),
-                physicalLayoutName = "titan2",
+                model = model,
+                physicalLayoutName = when (model) {
+                    KeyboardModel.TITAN_ORIGINAL -> "titan"
+                    else -> "titan2"
+                },
                 needsEventRemapping = false
             )
         }
@@ -305,6 +309,7 @@ object DeviceSpecific {
             "key2" -> KeyboardModel.KEY2
             "q25" -> KeyboardModel.Q25
             "titan2elite_qwerty" -> KeyboardModel.TITAN_2_ELITE_QWERTY
+            "titan" -> KeyboardModel.TITAN_ORIGINAL
             "titan2" -> KeyboardModel.TITAN_2
             "mp01" -> KeyboardModel.MINIMAL_PHONE
             else -> currentDeviceProfile().model
@@ -315,7 +320,7 @@ object DeviceSpecific {
         val normalized = physicalProfileOverride?.trim()?.lowercase().orEmpty()
         return when (normalized) {
             "", "auto" -> null
-            "key2", "q25", "titan2", "titan2elite_qwerty", "mp01" -> normalized
+            "key2", "q25", "titan", "titan2", "titan2elite_qwerty", "mp01" -> normalized
             else -> null
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,7 +290,8 @@
     <string name="keyboard_profile_option_auto">Auto</string>
     <string name="keyboard_profile_option_key2">BlackBerry Key2</string>
     <string name="keyboard_profile_option_q25">BlackBerry Q25</string>
-    <string name="keyboard_profile_option_titan2">Unihertz Titan / Titan 2</string>
+    <string name="keyboard_profile_option_titan">Unihertz Titan</string>
+    <string name="keyboard_profile_option_titan2">Unihertz Titan 2</string>
     <string name="keyboard_profile_option_titan2elite_qwerty">Titan 2 Elite (QWERTY)</string>
     <string name="keyboard_profile_option_mp01">Minimal Phone (MP01)</string>
     <string name="keyboard_currency_symbol_title">Currency Symbol</string>

--- a/app/src/test/java/it/palsoftware/pastiera/data/mappings/KeyMappingLoaderTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/data/mappings/KeyMappingLoaderTest.kt
@@ -57,6 +57,28 @@ class KeyMappingLoaderTest {
     }
 
     @Test
+    fun loadAltMappings_originalTitanAutoDetection_usesOriginalTitanAsset() {
+        val context = RuntimeEnvironment.getApplication()
+        SettingsManager.setPhysicalKeyboardProfileOverride(context, "auto")
+        DeviceSpecific.setBuildFingerprintForTests(
+            brand = "Unihertz",
+            manufacturer = "A-gold",
+            model = "Titan",
+            device = "Titan",
+            product = "Titan",
+            board = "g61v71c2k_dfl_tee",
+            display = "Titan_20221121"
+        )
+
+        val mappings = KeyMappingLoader.loadAltKeyMappings(context.assets, context)
+
+        assertTrue(mappings.size >= 26)
+        assertEquals(":", mappings[KeyEvent.KEYCODE_Q])
+        assertEquals("1", mappings[KeyEvent.KEYCODE_U])
+        assertEquals("9", mappings[KeyEvent.KEYCODE_M])
+    }
+
+    @Test
     fun loadSymPage2Mappings_exposesExpandedTypographyDefaults() {
         val context = RuntimeEnvironment.getApplication()
 

--- a/app/src/test/java/it/palsoftware/pastiera/inputmethod/DeviceSpecificTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/inputmethod/DeviceSpecificTest.kt
@@ -67,6 +67,24 @@ class DeviceSpecificTest {
     }
 
     @Test
+    fun originalTitanProfile_detectsOriginalTitanLayout() {
+        DeviceSpecific.setBuildFingerprintForTests(
+            brand = "Unihertz",
+            manufacturer = "A-gold",
+            model = "Titan",
+            device = "Titan",
+            product = "Titan",
+            board = "g61v71c2k_dfl_tee",
+            display = "Titan_20221121"
+        )
+
+        assertEquals("titan", DeviceSpecific.physicalKeyboardName())
+        assertEquals("Unihertz", DeviceSpecific.keyboardName())
+        assertFalse(DeviceSpecific.needsRemapping())
+        assertFalse(DeviceSpecific.isTitan2Device())
+    }
+
+    @Test
     fun minimalPhoneProfile_detectsMp01LayoutWithoutRemapping() {
         DeviceSpecific.setBuildFingerprintForTests(
             brand = "minimal",

--- a/app/src/test/java/it/palsoftware/pastiera/inputmethod/InputEventRouterModifierE2ETest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/inputmethod/InputEventRouterModifierE2ETest.kt
@@ -469,6 +469,10 @@ class InputEventRouterModifierE2ETest {
     @Test
     fun swipeToDelete_handlesBothKnownSwipeKeyCodes() {
         SettingsManager.setSwipeToDelete(context, true)
+        SettingsManager.setSwipeToDeleteProvider(
+            context,
+            SettingsManager.SWIPE_TO_DELETE_PROVIDER_TITAN2_KEYCODE
+        )
         inputConnectionRecorder.textBeforeCursor = "hello world"
         val callbacks = TestCallbacks(modifierStateController)
 


### PR DESCRIPTION
## Summary
- add a dedicated original Unihertz Titan Alt keymap from the issue attachment
- detect the original Titan as its own `titan` physical keyboard profile instead of reusing `titan2`
- expose the original Titan profile in keyboard profile settings
- credit glebkuchay for the original Titan keymap contribution

## Tests
- `./gradlew :app:testNightlyDebugUnitTest --tests it.palsoftware.pastiera.inputmethod.DeviceSpecificTest --tests it.palsoftware.pastiera.data.mappings.KeyMappingLoaderTest`

Fixes #222