### PR TITLE
feat: add default language setting

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/CustomInputStylesScreen.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/CustomInputStylesScreen.kt
@@ -78,6 +78,9 @@ fun CustomInputStylesScreen(
         mutableStateOf(loadCustomInputStyles(context))
     }
     
+    // Default input style (language + layout forced on every new input field; null = keep last used)
+    var defaultStyle by remember { mutableStateOf(SettingsManager.getDefaultInputStyle(context)) }
+
     // Dialog state
     var showAddDialog by remember { mutableStateOf(false) }
     var deleteConfirmStyle by remember { mutableStateOf<CustomInputStyle?>(null) }
@@ -169,6 +172,23 @@ fun CustomInputStylesScreen(
 
             item {
                 LayoutSwitchShortcutsCard()
+            }
+
+            item {
+                // Default layout selector: forces a chosen input style (language + layout)
+                // on every new input field
+                DefaultLayoutCard(
+                    inputStyles = inputStyles,
+                    selected = defaultStyle,
+                    onSelect = { locale, layout ->
+                        SettingsManager.setDefaultInputStyle(context, locale, layout)
+                        defaultStyle = if (locale != null && layout != null) {
+                            SettingsManager.DefaultInputStyle(locale, layout)
+                        } else {
+                            null
+                        }
+                    }
+                )
             }
 
             if (inputStyles.isEmpty()) {
@@ -372,6 +392,97 @@ fun CustomInputStylesScreen(
                 }
             }
         )
+    }
+}
+
+/**
+ * Card that lets the user pick a default input style (language + keyboard layout) which the
+ * keyboard switches to whenever a new text field is opened. Follows the same Card + dropdown
+ * layout as [AppLanguageSelectorCard] so all selectors on this screen share one look.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DefaultLayoutCard(
+    inputStyles: List<CustomInputStyle>,
+    selected: SettingsManager.DefaultInputStyle?,
+    onSelect: (locale: String?, layout: String?) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    val selectedLabel = if (selected == null) {
+        stringResource(R.string.default_layout_none)
+    } else {
+        "${getLocaleDisplayName(selected.locale)} - ${selected.layout}"
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Keyboard,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = stringResource(R.string.default_layout_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+
+            Text(
+                text = stringResource(R.string.default_layout_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = it }
+            ) {
+                OutlinedTextField(
+                    value = selectedLabel,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.default_layout_label)) },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                )
+
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    // "Last used" disables the feature (no forced input style)
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.default_layout_none)) },
+                        onClick = {
+                            onSelect(null, null)
+                            expanded = false
+                        }
+                    )
+                    inputStyles.forEach { style ->
+                        DropdownMenuItem(
+                            text = { Text(style.displayName) },
+                            onClick = {
+                                onSelect(style.locale, style.layout)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
@@ -86,6 +86,7 @@ object SettingsManager {
     private const val KEY_STATIC_VARIATION_BAR_MODIFIER_HOLD_RESTORATION = "static_variation_bar_modifier_hold_restoration"
     private const val KEY_VARIATIONS_UPDATED = "variations_updated" // Trigger for reloading variations in input method service
     private const val KEY_ADDITIONAL_IME_SUBTYPES = "additional_ime_subtypes" // Comma-separated list of language codes for additional IME subtypes
+    private const val KEY_DEFAULT_SUBTYPE_STYLE = "default_subtype_style" // Input style "locale:layout" (e.g. "en_US:qwerty") to force on every new input field; empty = keep last used
     private const val KEY_CLIPBOARD_HISTORY_ENABLED = "clipboard_history_enabled" // Whether clipboard history is enabled
     private const val KEY_CLIPBOARD_RETENTION_TIME = "clipboard_retention_time" // How long to keep clipboard entries (in minutes)
     private const val KEY_TRACKPAD_GESTURES_ENABLED = "trackpad_gestures_enabled" // Whether trackpad gesture suggestions are enabled
@@ -407,7 +408,46 @@ object SettingsManager {
             .putStringSet(KEY_ADDITIONAL_IME_SUBTYPES, normalized)
             .apply()
     }
-    
+
+    /**
+     * An input style (language + keyboard layout pair) used as the default subtype.
+     */
+    data class DefaultInputStyle(val locale: String, val layout: String)
+
+    /**
+     * Returns the input style (locale + layout, e.g. "en_US"/"qwerty") that should be forced
+     * when a new input field is opened, or null when the feature is disabled (the keyboard
+     * keeps the last used input style).
+     */
+    fun getDefaultInputStyle(context: Context): DefaultInputStyle? {
+        val raw = getPreferences(context)
+            .getString(KEY_DEFAULT_SUBTYPE_STYLE, "")
+            ?.trim()
+            .orEmpty()
+        if (raw.isEmpty()) return null
+        val separator = raw.indexOf(':')
+        if (separator <= 0 || separator >= raw.length - 1) return null
+        return DefaultInputStyle(
+            locale = raw.substring(0, separator),
+            layout = raw.substring(separator + 1)
+        )
+    }
+
+    /**
+     * Sets the default input style (language + layout) to force on every new input field.
+     * Pass null for either value to disable and keep the last used input style.
+     */
+    fun setDefaultInputStyle(context: Context, locale: String?, layout: String?) {
+        val value = if (locale.isNullOrBlank() || layout.isNullOrBlank()) {
+            ""
+        } else {
+            "${locale.trim()}:${layout.trim()}"
+        }
+        getPreferences(context).edit()
+            .putString(KEY_DEFAULT_SUBTYPE_STYLE, value)
+            .apply()
+    }
+
     /**
      * Returns the long-press threshold in milliseconds.
      */

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
@@ -1063,6 +1063,37 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
         }
     }
     
+    /**
+     * Forces the keyboard to the user-defined default input style (language + layout) when a new
+     * input field is opened. No-op when the feature is disabled or the default style is already active.
+     */
+    private fun enforceDefaultLanguageSubtype() {
+        val defaultStyle = SettingsManager.getDefaultInputStyle(this) ?: return
+        if (isLanguageSwitchInProgress) {
+            return
+        }
+        if (SubtypeCycler.getCurrentInputStyle(this, assets) == defaultStyle) {
+            return
+        }
+
+        isLanguageSwitchInProgress = true
+        try {
+            val switched = SubtypeCycler.switchToSubtypeByStyle(
+                context = this,
+                imeServiceClass = PhysicalKeyboardInputMethodService::class.java,
+                assets = assets,
+                targetLocale = defaultStyle.locale,
+                targetLayout = defaultStyle.layout,
+                showToast = false
+            )
+            val delayMs = if (switched) 300L else 0L
+            uiHandler.postDelayed({ isLanguageSwitchInProgress = false }, delayMs)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error enforcing default language subtype", e)
+            isLanguageSwitchInProgress = false
+        }
+    }
+
     private fun showPowerShortcutToast(message: String) {
         uiHandler.post {
             val now = System.currentTimeMillis()
@@ -2192,6 +2223,9 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
         // This ensures dynamic languages are loaded even if service was already created
         if (!restarting) {
             registerAdditionalSubtypes()
+            // Force the user-defined default language for each new input field, overriding
+            // whatever language was last used in the previous field.
+            enforceDefaultLanguageSubtype()
         }
 
         updateInputContextState(info)

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/SubtypeCycler.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/SubtypeCycler.kt
@@ -230,6 +230,89 @@ object SubtypeCycler {
     }
     
     /**
+     * Switches to the enabled subtype whose locale and keyboard layout match
+     * [targetLocale]/[targetLayout].
+     *
+     * Used to enforce a user-defined default input style when a new input field is opened.
+     * Does nothing (returns false) if no enabled subtype matches the style, if the IME
+     * is not found, or if the window token is unavailable.
+     *
+     * @return true if a switch was performed, false otherwise.
+     */
+    fun switchToSubtypeByStyle(
+        context: Context,
+        imeServiceClass: Class<*>,
+        assets: AssetManager,
+        targetLocale: String,
+        targetLayout: String,
+        showToast: Boolean = false
+    ): Boolean {
+        return try {
+            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+                ?: return false
+
+            // Already on the requested input style -> nothing to do
+            val current = imm.currentInputMethodSubtype
+            if (current != null &&
+                current.localeString() == targetLocale &&
+                resolveSubtypeCycleLayout(assets, context, current) == targetLayout
+            ) {
+                return false
+            }
+
+            val packageName = context.packageName
+            val serviceName = imeServiceClass.name
+            val inputMethodInfo = imm.getInputMethodList().firstOrNull { info ->
+                info.packageName == packageName && info.serviceName == serviceName
+            } ?: run {
+                Log.w(TAG, "IME not found for default-style switch: $packageName/$serviceName")
+                return false
+            }
+
+            val enabledSubtypes = imm.getEnabledInputMethodSubtypeList(inputMethodInfo, true)
+            val targetSubtype = enabledSubtypes.firstOrNull { subtype ->
+                subtype.localeString() == targetLocale &&
+                    resolveSubtypeCycleLayout(assets, context, subtype) == targetLayout
+            } ?: run {
+                Log.d(TAG, "No enabled subtype matches default style '$targetLocale:$targetLayout', skipping")
+                return false
+            }
+
+            val switched = trySwitchSubtype(imm, inputMethodInfo.id, targetSubtype, context)
+            if (switched) {
+                SettingsManager.setKeyboardLayout(context, targetLayout)
+                Log.d(TAG, "Forced default input style: $targetLocale:$targetLayout")
+                if (showToast) {
+                    showUnifiedSubtypeToast(context, targetSubtype, assets)
+                }
+            }
+            switched
+        } catch (e: Exception) {
+            Log.e(TAG, "Error switching to default input style '$targetLocale:$targetLayout'", e)
+            false
+        }
+    }
+
+    /**
+     * Gets the current IME subtype's input style (locale + resolved keyboard layout),
+     * or null if unavailable.
+     */
+    fun getCurrentInputStyle(context: Context, assets: AssetManager): SettingsManager.DefaultInputStyle? {
+        return try {
+            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+            val subtype = imm?.currentInputMethodSubtype ?: return null
+            val locale = subtype.localeString().ifBlank { return null }
+            SettingsManager.DefaultInputStyle(
+                locale = locale,
+                layout = resolveSubtypeCycleLayout(assets, context, subtype)
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting current input style", e)
+            null
+        }
+    }
+
+    /**
      * Gets the current subtype display name.
      */
     fun getCurrentSubtypeName(context: Context): String? {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -855,6 +855,12 @@ Each key can be configured as Keycode, Action, Native Ctrl, or None. Use overrid
     <!-- Units -->
     <string name="dip_unit">DIP</string>
     
+    <!-- Default layout -->
+    <string name="default_layout_title">Default layout</string>
+    <string name="default_layout_description">Always start in this language and keyboard layout when a text field opens.</string>
+    <string name="default_layout_none">Last used</string>
+    <string name="default_layout_label">Layout</string>
+
     <!-- Custom Input Styles -->
     <string name="custom_input_styles_title">Languages and Keyboard Layouts</string>
     <string name="custom_input_styles_description">Add additional languages and keyboard layouts that are not tied to system locale</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -856,7 +856,7 @@ Each key can be configured as Keycode, Action, Native Ctrl, or None. Use overrid
     <string name="dip_unit">DIP</string>
     
     <!-- Default layout -->
-    <string name="default_layout_title">Default layout</string>
+    <string name="default_layout_title">Default Layout</string>
     <string name="default_layout_description">Always start in this language and keyboard layout when a text field opens.</string>
     <string name="default_layout_none">Last used</string>
     <string name="default_layout_label">Layout</string>


### PR DESCRIPTION
Description:
Adds a 'Default layout' option that makes the keyboard always start  in a chosen language when a new text field is opened, instead of keeping the last used. Defaults to "Last used" to keep current behaviour.

Reason: 
Currently, after switching language, it stays until you manually switch back. If you type mostly in one language, this means constantly changing the layout. Pinning a default language makes the keyboard reliably return to primary language on each typing and you always know which language is currently selected.

![Screenshot_20260604-001421.png](https://github.com/user-attachments/assets/4b0e6ee2-1d81-48e8-9ab1-fa3074baac23)


