### PR TITLE
feat: add Alt+Enter layout switch option

### DIFF
--- a/app/src/main/assets/common/about_credits.md
+++ b/app/src/main/assets/common/about_credits.md
@@ -8,7 +8,7 @@ Andrea Palumbo (PalSoftware)
 Andrea Palumbo, Patrick Zauner
 
 #### Additional Contributors
-Justin Mitchell, NeoTheFox, Oleksii Ilienko, Nikola Vukobrat, Mircea Horea IONICĂ, Nikita Tseykovets, Ivan Bulanov, Ratmir Karabut, Troidem, Vasu Bhatia, Zsolt Sz. Sz. Raven, Burekmaster (SVG logo assets), glebkuchay
+Justin Mitchell, NeoTheFox, Oleksii Ilienko, Nikola Vukobrat, Mircea Horea IONICĂ, Nikita Tseykovets, Ivan Bulanov, Ratmir Karabut, Troidem, Vasu Bhatia, Zsolt Sz. Sz. Raven, Burekmaster (SVG logo assets), glebkuchay, drpepper240
 ---
 #### Pastiera Beta Testing Team
 Laggy Luke, Vittorio, Emmanuel, Sadako, NotTeganQuinn, DrumSyBeat, [Shane Craig (ShaneCraig.Tech)](https://shanecraig.tech/)

--- a/app/src/main/java/it/palsoftware/pastiera/CustomInputStylesScreen.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/CustomInputStylesScreen.kt
@@ -381,6 +381,9 @@ private fun LayoutSwitchShortcutsCard() {
     var altShiftLayoutSwitch by remember {
         mutableStateOf(SettingsManager.isAltShiftLayoutSwitchEnabled(context))
     }
+    var altEnterLayoutSwitch by remember {
+        mutableStateOf(SettingsManager.isAltEnterLayoutSwitchEnabled(context))
+    }
     var ctrlSpaceLayoutSwitch by remember {
         mutableStateOf(SettingsManager.isCtrlSpaceLayoutSwitchEnabled(context))
     }
@@ -418,6 +421,16 @@ private fun LayoutSwitchShortcutsCard() {
                 onCheckedChange = { enabled ->
                     altShiftLayoutSwitch = enabled
                     SettingsManager.setAltShiftLayoutSwitchEnabled(context, enabled)
+                }
+            )
+
+            LayoutSwitchShortcutRow(
+                title = stringResource(R.string.alt_enter_layout_switch_title),
+                description = stringResource(R.string.alt_enter_layout_switch_description),
+                checked = altEnterLayoutSwitch,
+                onCheckedChange = { enabled ->
+                    altEnterLayoutSwitch = enabled
+                    SettingsManager.setAltEnterLayoutSwitchEnabled(context, enabled)
                 }
             )
 

--- a/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
@@ -3413,7 +3413,7 @@ object SettingsManager {
     }
 
     /**
-     * Enables/disables Alt+Shift shortcut for keyboard layout cycling.
+     * Enables/disables Alt+Enter shortcut for keyboard layout cycling.
      */
     fun setAltEnterLayoutSwitchEnabled(context: Context, enabled: Boolean) {
         getPreferences(context).edit()

--- a/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/SettingsManager.kt
@@ -63,6 +63,7 @@ object SettingsManager {
     const val KEY_KEYBOARD_LAYOUT_AUTO_MAPPING_UPDATED = "keyboard_layout_auto_mapping_updated"
     private const val KEY_KEYBOARD_LAYOUT_LIST = "keyboard_layout_list" // JSON array of layout ids for cycling
     private const val KEY_ALT_SHIFT_LAYOUT_SWITCH = "alt_shift_layout_switch" // Enable Alt+Shift shortcut for layout cycling
+    private const val KEY_ALT_ENTER_LAYOUT_SWITCH = "alt_enter_layout_switch" // Enable Alt+Enter shortcut for layout cycling
     private const val KEY_CTRL_SPACE_LAYOUT_SWITCH = "ctrl_space_layout_switch" // Enable Ctrl+Space shortcut for layout cycling
     private const val KEY_PHYSICAL_KEYBOARD_PROFILE_OVERRIDE = "physical_keyboard_profile_override" // auto | key2 | Q25 | titan | titan2 | titan2elite_qwerty | mp01
     private const val KEY_PHYSICAL_KEYBOARD_CURRENCY_SYMBOL = "physical_keyboard_currency_symbol" // Currency symbol for dedicated hardware keys
@@ -243,6 +244,7 @@ object SettingsManager {
     private const val DEFAULT_KEYBOARD_LAYOUT = "qwerty"
     private const val DEFAULT_KEYBOARD_LAYOUT_AUTO_BY_LOCALE = true
     private const val DEFAULT_ALT_SHIFT_LAYOUT_SWITCH = true
+    private const val DEFAULT_ALT_ENTER_LAYOUT_SWITCH = false
     private const val DEFAULT_CTRL_SPACE_LAYOUT_SWITCH = true
     private const val KEY_TOAST_ON_LAYOUT_SWITCH = "toast_on_layout_switch"
     private const val DEFAULT_TOAST_ON_LAYOUT_SWITCH = true
@@ -3397,6 +3399,25 @@ object SettingsManager {
     fun setAltShiftLayoutSwitchEnabled(context: Context, enabled: Boolean) {
         getPreferences(context).edit()
             .putBoolean(KEY_ALT_SHIFT_LAYOUT_SWITCH, enabled)
+            .apply()
+    }
+
+    /**
+     * Returns whether Alt+Enter shortcut for keyboard layout cycling is enabled.
+     */
+    fun isAltEnterLayoutSwitchEnabled(context: Context): Boolean {
+        return getPreferences(context).getBoolean(
+            KEY_ALT_ENTER_LAYOUT_SWITCH,
+            DEFAULT_ALT_ENTER_LAYOUT_SWITCH
+        )
+    }
+
+    /**
+     * Enables/disables Alt+Shift shortcut for keyboard layout cycling.
+     */
+    fun setAltEnterLayoutSwitchEnabled(context: Context, enabled: Boolean) {
+        getPreferences(context).edit()
+            .putBoolean(KEY_ALT_ENTER_LAYOUT_SWITCH, enabled)
             .apply()
     }
 

--- a/app/src/main/java/it/palsoftware/pastiera/backup/BackupContract.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/backup/BackupContract.kt
@@ -296,7 +296,8 @@ object PreferenceSchemas {
             "ctrl_space_layout_switch" to PreferenceValueType.BOOLEAN,
             "physical_keyboard_currency_symbol" to PreferenceValueType.STRING,
             "toast_on_layout_switch" to PreferenceValueType.BOOLEAN,
-            "software_keyboard_mode_toggle_toasts" to PreferenceValueType.BOOLEAN
+            "software_keyboard_mode_toggle_toasts" to PreferenceValueType.BOOLEAN,
+            "alt_enter_layout_switch" to PreferenceValueType.BOOLEAN
         ),
         dynamicKeys = listOf(
             PreferenceFileSchema.DynamicKey(

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
@@ -135,6 +135,7 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
     private var lastLayoutToastTime: Long = 0
     private var suppressNextLayoutReload: Boolean = false
     private var activeKeyboardLayoutName: String = "qwerty"
+    private var consumeAltEnterUntilKeyUp: Boolean = false
     
     // Aggiungi per Power Shortcuts
     private var powerShortcutToast: android.widget.Toast? = null
@@ -3787,6 +3788,16 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
             return true
         }
 
+        if (keyCode == KeyEvent.KEYCODE_ENTER && event?.repeatCount == 0) {
+            // Recover if a previous chord lost its key-up while the input context changed.
+            consumeAltEnterUntilKeyUp = false
+        }
+
+        // Keep repeats from a consumed Alt+Enter chord away from the editor.
+        if (keyCode == KeyEvent.KEYCODE_ENTER && consumeAltEnterUntilKeyUp) {
+            return true
+        }
+
         // Handle Alt+Enter for subtype cycling
         if (
             hasEditableField &&
@@ -3796,6 +3807,7 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
             (keyCode == KeyEvent.KEYCODE_ENTER &&
                     (event.isAltPressed || altPhysicallyPressed))
         ) {
+            consumeAltEnterUntilKeyUp = true
             modifierStateController.clearAltState(resetPressedState = true)
 
             val showToast = SettingsManager.isToastOnLayoutSwitchEnabled(this)
@@ -4033,6 +4045,10 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
 
     override fun onKeyUp(keyCode_: Int, event_: KeyEvent?): Boolean {
         val (keyCode, event) = remapHardwareEvent(keyCode_, event_)
+        if (keyCode == KeyEvent.KEYCODE_ENTER && consumeAltEnterUntilKeyUp) {
+            consumeAltEnterUntilKeyUp = false
+            return true
+        }
         bounceKeyFilter.shouldConsumeKeyUp(keyCode, event)?.let { suppressed ->
             notifyDebugKeyEvent(
                 keyCode = keyCode,

--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
@@ -3787,6 +3787,29 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
             return true
         }
 
+        // Handle Alt+Enter for subtype cycling
+        if (
+            hasEditableField &&
+            event != null &&
+            event.repeatCount == 0 &&
+            SettingsManager.isAltEnterLayoutSwitchEnabled(this) &&
+            (keyCode == KeyEvent.KEYCODE_ENTER &&
+                    (event.isAltPressed || altPhysicallyPressed))
+        ) {
+            modifierStateController.clearAltState(resetPressedState = true)
+
+            val showToast = SettingsManager.isToastOnLayoutSwitchEnabled(this)
+            SubtypeCycler.cycleToNextSubtype(
+                context = this,
+                imeServiceClass = PhysicalKeyboardInputMethodService::class.java,
+                assets = assets,
+                showToast = showToast
+            )
+
+            updateStatusBarText()
+            return true
+        }
+
         // Handle Ctrl+Space for subtype cycling
         if (
             hasEditableField &&

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,6 +306,8 @@
     <string name="keyboard_layout_mode_manual_description">OFF: use one manually selected layout for all locales.</string>
     <string name="alt_shift_layout_switch_title">Alt+Shift Layout Switch</string>
     <string name="alt_shift_layout_switch_description">Cycle languages/layouts with Alt+Shift.</string>
+    <string name="alt_enter_layout_switch_title">Alt+Enter Layout Switch</string>
+    <string name="alt_enter_layout_switch_description">Cycle languages/layouts with Alt+Enter.</string>
     <string name="ctrl_space_layout_switch_title">Ctrl+Space Layout Switch</string>
     <string name="ctrl_space_layout_switch_description">Cycle languages/layouts with Ctrl+Space.</string>
     <string name="layout_switch_shortcuts_title">Layout Switch Shortcuts</string>

--- a/app/src/test/java/it/palsoftware/pastiera/SettingsManagerLayoutSwitchTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/SettingsManagerLayoutSwitchTest.kt
@@ -44,8 +44,12 @@ class SettingsManagerLayoutSwitchTest {
     }
 
     @Test
-    fun altEnterLayoutSwitch_defaultsEnabled_andPersistsDisabledState() {
+    fun altEnterLayoutSwitch_defaultsDisabled_andPersistsState() {
         val context = RuntimeEnvironment.getApplication()
+
+        assertFalse(SettingsManager.isAltEnterLayoutSwitchEnabled(context))
+
+        SettingsManager.setAltEnterLayoutSwitchEnabled(context, true)
 
         assertTrue(SettingsManager.isAltEnterLayoutSwitchEnabled(context))
 

--- a/app/src/test/java/it/palsoftware/pastiera/SettingsManagerLayoutSwitchTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/SettingsManagerLayoutSwitchTest.kt
@@ -44,6 +44,17 @@ class SettingsManagerLayoutSwitchTest {
     }
 
     @Test
+    fun altEnterLayoutSwitch_defaultsEnabled_andPersistsDisabledState() {
+        val context = RuntimeEnvironment.getApplication()
+
+        assertTrue(SettingsManager.isAltEnterLayoutSwitchEnabled(context))
+
+        SettingsManager.setAltEnterLayoutSwitchEnabled(context, false)
+
+        assertFalse(SettingsManager.isAltEnterLayoutSwitchEnabled(context))
+    }
+
+    @Test
     fun ctrlSpaceLayoutSwitch_defaultsEnabled_andPersistsDisabledState() {
         val context = RuntimeEnvironment.getApplication()
 

--- a/app/src/test/java/it/palsoftware/pastiera/backup/RestoreManagerAndBackupContractTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/backup/RestoreManagerAndBackupContractTest.kt
@@ -30,6 +30,10 @@ class RestoreManagerAndBackupContractTest {
         )
         assertEquals(
             PreferenceValueType.BOOLEAN,
+            PreferenceSchemas.expectedType("pastiera_prefs", "alt_enter_layout_switch")
+        )
+        assertEquals(
+            PreferenceValueType.BOOLEAN,
             PreferenceSchemas.expectedType("pastiera_prefs", "toast_on_layout_switch")
         )
         assertEquals(

--- a/app/src/test/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodServiceDeviceBehaviorTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodServiceDeviceBehaviorTest.kt
@@ -305,6 +305,37 @@ class PhysicalKeyboardInputMethodServiceDeviceBehaviorTest {
     }
 
     @Test
+    fun altEnterLayoutSwitch_consumesShortcutAndClearsModifiers_whenEnabled() {
+        val context = RuntimeEnvironment.getApplication()
+        SettingsManager.setAltEnterLayoutSwitchEnabled(context, true)
+        val t0 = 3_900L
+
+        service.onKeyDown(
+            KeyEvent.KEYCODE_ALT_LEFT,
+            keyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ALT_LEFT, t0, t0)
+        )
+        assertTrue(modifierController().altPressed)
+
+        val handled = service.onKeyDown(
+            KeyEvent.KEYCODE_ENTER,
+            keyEvent(
+                action = KeyEvent.ACTION_DOWN,
+                keyCode = KeyEvent.KEYCODE_ENTER,
+                downTime = t0,
+                eventTime = t0 + 80L,
+                metaState = KeyEvent.META_ALT_ON or KeyEvent.META_ALT_LEFT_ON
+            )
+        )
+
+        val modifier = modifierController()
+        assertTrue(handled)
+        assertFalse(modifier.altPressed)
+        assertFalse(modifier.altPhysicallyPressed)
+        assertFalse(modifier.altOneShot)
+        assertFalse(modifier.altLatchActive)
+    }
+
+    @Test
     fun deviceSanity_symATogglesEmojiThenSymbols_exactMappings() {
         val t0 = 4_000L
 

--- a/app/src/test/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodServiceDeviceBehaviorTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodServiceDeviceBehaviorTest.kt
@@ -333,6 +333,105 @@ class PhysicalKeyboardInputMethodServiceDeviceBehaviorTest {
         assertFalse(modifier.altPhysicallyPressed)
         assertFalse(modifier.altOneShot)
         assertFalse(modifier.altLatchActive)
+
+        val keyUpHandled = service.onKeyUp(
+            KeyEvent.KEYCODE_ENTER,
+            keyEvent(
+                action = KeyEvent.ACTION_UP,
+                keyCode = KeyEvent.KEYCODE_ENTER,
+                downTime = t0,
+                eventTime = t0 + 100L,
+                metaState = KeyEvent.META_ALT_ON or KeyEvent.META_ALT_LEFT_ON
+            )
+        )
+        assertTrue(keyUpHandled)
+    }
+
+    @Test
+    fun altEnterLayoutSwitch_doesNotConsumeWhenDisabled() {
+        val context = RuntimeEnvironment.getApplication()
+        SettingsManager.setAltEnterLayoutSwitchEnabled(context, false)
+        setField(service, "clearAltOnSpaceEnabled", false)
+        val t0 = 3_920L
+
+        service.onKeyDown(
+            KeyEvent.KEYCODE_ALT_LEFT,
+            keyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ALT_LEFT, t0, t0)
+        )
+        service.onKeyDown(
+            KeyEvent.KEYCODE_ENTER,
+            keyEvent(
+                action = KeyEvent.ACTION_DOWN,
+                keyCode = KeyEvent.KEYCODE_ENTER,
+                downTime = t0,
+                eventTime = t0 + 80L,
+                metaState = KeyEvent.META_ALT_ON or KeyEvent.META_ALT_LEFT_ON
+            )
+        )
+
+        assertTrue(modifierController().altPhysicallyPressed)
+    }
+
+    @Test
+    fun altEnterLayoutSwitch_consumesKeyRepeatsUntilKeyUp() {
+        val context = RuntimeEnvironment.getApplication()
+        SettingsManager.setAltEnterLayoutSwitchEnabled(context, true)
+        val t0 = 3_940L
+
+        service.onKeyDown(
+            KeyEvent.KEYCODE_ALT_LEFT,
+            keyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ALT_LEFT, t0, t0)
+        )
+        service.onKeyDown(
+            KeyEvent.KEYCODE_ENTER,
+            keyEvent(
+                action = KeyEvent.ACTION_DOWN,
+                keyCode = KeyEvent.KEYCODE_ENTER,
+                downTime = t0,
+                eventTime = t0 + 80L,
+                metaState = KeyEvent.META_ALT_ON or KeyEvent.META_ALT_LEFT_ON
+            )
+        )
+
+        val repeatedHandled = service.onKeyDown(
+            KeyEvent.KEYCODE_ENTER,
+            keyEvent(
+                action = KeyEvent.ACTION_DOWN,
+                keyCode = KeyEvent.KEYCODE_ENTER,
+                downTime = t0,
+                eventTime = t0 + 160L,
+                metaState = KeyEvent.META_ALT_ON or KeyEvent.META_ALT_LEFT_ON,
+                repeatCount = 1
+            )
+        )
+
+        assertTrue(repeatedHandled)
+        assertFalse(recorder.committedTexts.contains("\n"))
+        assertTrue(recorder.sentKeyEvents.isEmpty())
+    }
+
+    @Test
+    fun altEnterLayoutSwitch_doesNotTriggerWhenEnterIsPressedFirst() {
+        val context = RuntimeEnvironment.getApplication()
+        SettingsManager.setAltEnterLayoutSwitchEnabled(context, true)
+        val t0 = 3_960L
+
+        service.onKeyDown(
+            KeyEvent.KEYCODE_ENTER,
+            keyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER, t0, t0)
+        )
+        service.onKeyDown(
+            KeyEvent.KEYCODE_ALT_LEFT,
+            keyEvent(
+                action = KeyEvent.ACTION_DOWN,
+                keyCode = KeyEvent.KEYCODE_ALT_LEFT,
+                downTime = t0 + 80L,
+                eventTime = t0 + 80L
+            )
+        )
+
+        assertTrue(modifierController().altPressed)
+        assertTrue(modifierController().altPhysicallyPressed)
     }
 
     @Test
@@ -493,9 +592,10 @@ class PhysicalKeyboardInputMethodServiceDeviceBehaviorTest {
         keyCode: Int,
         downTime: Long,
         eventTime: Long,
-        metaState: Int = 0
+        metaState: Int = 0,
+        repeatCount: Int = 0
     ): KeyEvent {
-        return KeyEvent(downTime, eventTime, action, keyCode, 0, metaState)
+        return KeyEvent(downTime, eventTime, action, keyCode, repeatCount, metaState)
     }
 
     private fun modifierController(): ModifierStateController {


### PR DESCRIPTION
Alt+Enter is the default layout switching combination on numerous BlackBerry devices (including Android, BB10 and even older platforms). It normally works by pressing and holding Alt then pressing Enter, doing it the other way around (Enter first, Alt second) does not work on Blackberry (tested with Q10 and KeyOne). Otherwise it is similar to already implemented Alt+Shift switching option #173.