### PR TITLE
fix: consume Shift on Enter

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodService.kt
@@ -4003,6 +4003,9 @@ class PhysicalKeyboardInputMethodService : InputMethodService() {
         val isAutoCorrectEnabled = SettingsManager.getAutoCorrectEnabled(this) && !state.shouldDisableAutoCorrect
 
         clearAltOnBoundaryIfNeeded(keyCode) { updateStatusBarText() }
+        if (keyCode == KeyEvent.KEYCODE_ENTER && modifierStateController.consumeShiftOneShot()) {
+            updateStatusBarText()
+        }
 
         if (handleEnterAsEditorAction(
                 keyCode,

--- a/app/src/test/java/it/palsoftware/pastiera/core/TextInputControllerTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/core/TextInputControllerTest.kt
@@ -104,6 +104,38 @@ class TextInputControllerTest {
     }
 
     @Test
+    fun autoCapAfterEnter_requestsFreshShiftAfterNewline_whenEnabled() {
+        SettingsManager.setAutoCapitalizeFirstLetter(context, true)
+        SettingsManager.setAutoCapitalizeAfterPeriod(context, false)
+        val inputConnection = FakeInputConnection(context, "hello\n")
+
+        controller.handleAutoCapAfterEnter(
+            keyCode = KeyEvent.KEYCODE_ENTER,
+            inputConnection = inputConnection,
+            shouldDisableAutoCapitalize = false,
+            onStatusBarUpdate = {}
+        )
+
+        assertTrue(modifierStateController.shiftOneShot)
+    }
+
+    @Test
+    fun autoCapAfterEnter_keepsShiftOffAfterNewline_whenDisabled() {
+        SettingsManager.setAutoCapitalizeFirstLetter(context, false)
+        SettingsManager.setAutoCapitalizeAfterPeriod(context, false)
+        val inputConnection = FakeInputConnection(context, "hello\n")
+
+        controller.handleAutoCapAfterEnter(
+            keyCode = KeyEvent.KEYCODE_ENTER,
+            inputConnection = inputConnection,
+            shouldDisableAutoCapitalize = false,
+            onStatusBarUpdate = {}
+        )
+
+        assertFalse(modifierStateController.shiftOneShot)
+    }
+
+    @Test
     fun spacedHyphenToEnDash_enabled_replacesMidSentenceHyphenWhenSpaceIsPressed() {
         SettingsManager.setSpacedHyphenToEnDash(context, true)
         val inputConnection = FakeInputConnection(context, "hello -")

--- a/app/src/test/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodServiceDeviceBehaviorTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/inputmethod/PhysicalKeyboardInputMethodServiceDeviceBehaviorTest.kt
@@ -177,6 +177,49 @@ class PhysicalKeyboardInputMethodServiceDeviceBehaviorTest {
     }
 
     @Test
+    fun shiftEnter_consumesManualShift_whenAutoCapitalizeAtLineStartIsDisabled() {
+        val context = RuntimeEnvironment.getApplication()
+        SettingsManager.setAutoCapitalizeFirstLetter(context, false)
+        SettingsManager.setAutoCapitalizeAfterPeriod(context, false)
+        editorInfo.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+        setField(service, "mInputEditorInfo", editorInfo)
+        setField(service, "inputContextState", InputContextState.fromEditorInfo(editorInfo))
+        val t0 = 2_700L
+
+        service.onKeyDown(
+            KeyEvent.KEYCODE_SHIFT_LEFT,
+            keyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SHIFT_LEFT, t0, t0)
+        )
+        service.onKeyDown(
+            KeyEvent.KEYCODE_ENTER,
+            keyEvent(
+                action = KeyEvent.ACTION_DOWN,
+                keyCode = KeyEvent.KEYCODE_ENTER,
+                downTime = t0,
+                eventTime = t0 + 80L,
+                metaState = KeyEvent.META_SHIFT_ON or KeyEvent.META_SHIFT_LEFT_ON
+            )
+        )
+        service.onKeyUp(
+            KeyEvent.KEYCODE_SHIFT_LEFT,
+            keyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SHIFT_LEFT, t0, t0 + 120L)
+        )
+
+        val modifier = modifierController()
+        assertFalse(modifier.shiftPressed)
+        assertFalse(modifier.shiftPhysicallyPressed)
+        assertFalse(modifier.shiftOneShot)
+        assertFalse(modifier.capsLockEnabled)
+
+        service.onKeyDown(
+            KeyEvent.KEYCODE_A,
+            keyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_A, t0 + 200L, t0 + 200L)
+        )
+        assertTrue("commits=${recorder.committedTexts}", recorder.committedTexts.contains("a"))
+        assertFalse("commits=${recorder.committedTexts}", recorder.committedTexts.contains("A"))
+    }
+
+    @Test
     fun deviceSanity_ctrlLatch_canBeDisabledByAnotherCtrlTap() {
         val t0 = 3_000L
         tapCtrl(t0)


### PR DESCRIPTION
## Summary

- consume a manual Shift one-shot when Enter is pressed
- preserve smart capitalization by allowing it to request a fresh Shift after the newline
- add service-level and controller regression coverage for both setting states

## Root cause

A physical Shift press created a one-shot state that Enter did not consume. With automatic capitalization at line starts disabled, the stale one-shot incorrectly uppercased the next character.

## Validation

- `PhysicalKeyboardInputMethodServiceDeviceBehaviorTest`
- `TextInputControllerTest`
- `ModifierStateControllerTest`
- built and installed `0.86-nightly.20260718.125918` with `scripts/build-nightly-debug.sh`
- confirmed on a Titan 2 with automatic capitalization both disabled and enabled

Fixes #241