### PR TITLE
fix: make alternative delete methods settings restorable from backup

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/backup/BackupContract.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/backup/BackupContract.kt
@@ -323,7 +323,10 @@ object PreferenceSchemas {
             "clicks_charging_stop_percent" to PreferenceValueType.INT,
             "toast_on_layout_switch" to PreferenceValueType.BOOLEAN,
             "software_keyboard_mode_toggle_toasts" to PreferenceValueType.BOOLEAN,
-            "alt_enter_layout_switch" to PreferenceValueType.BOOLEAN
+            "alt_enter_layout_switch" to PreferenceValueType.BOOLEAN,
+            "shift_backspace_delete" to PreferenceValueType.BOOLEAN,
+            "alt_backspace_delete" to PreferenceValueType.BOOLEAN,
+            "backspace_at_start_delete" to PreferenceValueType.BOOLEAN
         ),
         dynamicKeys = listOf(
             PreferenceFileSchema.DynamicKey(

--- a/app/src/test/java/it/palsoftware/pastiera/backup/RestoreManagerAndBackupContractTest.kt
+++ b/app/src/test/java/it/palsoftware/pastiera/backup/RestoreManagerAndBackupContractTest.kt
@@ -75,6 +75,22 @@ class RestoreManagerAndBackupContractTest {
     }
 
     @Test
+    fun deleteMethodsPreferences_areRecognizedForRestore() {
+        assertEquals(
+            PreferenceValueType.BOOLEAN,
+            PreferenceSchemas.expectedType("pastiera_prefs", "shift_backspace_delete")
+        )
+        assertEquals(
+            PreferenceValueType.BOOLEAN,
+            PreferenceSchemas.expectedType("pastiera_prefs", "alt_backspace_delete")
+        )
+        assertEquals(
+            PreferenceValueType.BOOLEAN,
+            PreferenceSchemas.expectedType("pastiera_prefs", "backspace_at_start_delete")
+        )
+    }
+
+    @Test
     fun statusBarAndVariationPreferences_areRecognizedForRestore() {
         assertEquals(
             PreferenceValueType.BOOLEAN,


### PR DESCRIPTION
"Alternative methods to delete characters to the right of cursor" options were not available for restore from backups previously. @pzauner could you please confirm that this was not intentional?