### PR TITLE
fix: setup screen clipping the status bar

### DIFF
--- a/app/src/main/java/it/palsoftware/pastiera/MainActivity.kt
+++ b/app/src/main/java/it/palsoftware/pastiera/MainActivity.kt
@@ -518,7 +518,7 @@ fun KeyboardSetupScreen(
     }
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION
PR fixes pastiera clipping the statusbar, making the settings button hard to hit:

<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/88884478-743d-4697-b323-e7d6ed477e59" />
